### PR TITLE
Allow passing the hasher.

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -11,11 +11,11 @@ use std::sync::Arc;
 
 type GuardIter<'a, K, V, S> = (
     Arc<RwLockReadGuard<'a, HashMap<K, V, S>>>,
-    hash_map::Iter<'a, K, SharedValue<V>, S>,
+    hash_map::Iter<'a, K, SharedValue<V>>,
 );
 type GuardIterMut<'a, K, V, S> = (
     Arc<RwLockWriteGuard<'a, HashMap<K, V, S>>>,
-    hash_map::IterMut<'a, K, SharedValue<V>, S>,
+    hash_map::IterMut<'a, K, SharedValue<V>>,
 );
 
 /// Iterator over a DashMap yielding immutable references.

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -5,16 +5,17 @@ use crate::util::SharedValue;
 use crate::HashMap;
 use parking_lot::{RwLockReadGuard, RwLockWriteGuard};
 use std::collections::hash_map;
-use std::hash::Hash;
+use std::hash::{BuildHasher, Hash};
+use std::marker::PhantomData;
 use std::sync::Arc;
 
-type GuardIter<'a, K, V> = (
-    Arc<RwLockReadGuard<'a, HashMap<K, V>>>,
-    hash_map::Iter<'a, K, SharedValue<V>>,
+type GuardIter<'a, K, V, S> = (
+    Arc<RwLockReadGuard<'a, HashMap<K, V, S>>>,
+    hash_map::Iter<'a, K, SharedValue<V>, S>,
 );
-type GuardIterMut<'a, K, V> = (
-    Arc<RwLockWriteGuard<'a, HashMap<K, V>>>,
-    hash_map::IterMut<'a, K, SharedValue<V>>,
+type GuardIterMut<'a, K, V, S> = (
+    Arc<RwLockWriteGuard<'a, HashMap<K, V, S>>>,
+    hash_map::IterMut<'a, K, SharedValue<V>, S>,
 );
 
 /// Iterator over a DashMap yielding immutable references.
@@ -28,30 +29,37 @@ type GuardIterMut<'a, K, V> = (
 /// map.insert("hello", "world");
 /// assert_eq!(map.iter().count(), 1);
 /// ```
-pub struct Iter<'a, K: Eq + Hash, V, M: Map<'a, K, V>> {
+pub struct Iter<'a, K: Eq + Hash, V, S: 'a + BuildHasher, M: Map<'a, K, V, S>> {
     map: &'a M,
     shard_i: usize,
-    current: Option<GuardIter<'a, K, V>>,
+    current: Option<GuardIter<'a, K, V, S>>,
+    phantom: PhantomData<S>,
 }
 
-unsafe impl<'a, K: Eq + Hash + Send, V: Send, M: Map<'a, K, V>> Send for Iter<'a, K, V, M> {}
-unsafe impl<'a, K: Eq + Hash + Send + Sync, V: Send + Sync, M: Map<'a, K, V>> Sync
-    for Iter<'a, K, V, M>
+unsafe impl<'a, K: Eq + Hash + Send, V: Send, S: 'a + BuildHasher, M: Map<'a, K, V, S>> Send
+    for Iter<'a, K, V, S, M>
+{
+}
+unsafe impl<'a, K: Eq + Hash + Send + Sync, V: Send + Sync, S: 'a + BuildHasher, M: Map<'a, K, V, S>>
+    Sync for Iter<'a, K, V, S, M>
 {
 }
 
-impl<'a, K: Eq + Hash, V, M: Map<'a, K, V>> Iter<'a, K, V, M> {
+impl<'a, K: Eq + Hash, V, S: 'a + BuildHasher, M: Map<'a, K, V, S>> Iter<'a, K, V, S, M> {
     pub(crate) fn new(map: &'a M) -> Self {
         Self {
             map,
             shard_i: 0,
             current: None,
+            phantom: PhantomData,
         }
     }
 }
 
-impl<'a, K: Eq + Hash, V, M: Map<'a, K, V>> Iterator for Iter<'a, K, V, M> {
-    type Item = RefMulti<'a, K, V>;
+impl<'a, K: Eq + Hash, V, S: 'a + BuildHasher, M: Map<'a, K, V, S>> Iterator
+    for Iter<'a, K, V, S, M>
+{
+    type Item = RefMulti<'a, K, V, S>;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -67,7 +75,7 @@ impl<'a, K: Eq + Hash, V, M: Map<'a, K, V>> Iterator for Iter<'a, K, V, M> {
         }
 
         let guard = unsafe { self.map._yield_read_shard(self.shard_i) };
-        let sref: &HashMap<K, V> = unsafe { util::change_lifetime_const(&*guard) };
+        let sref: &HashMap<K, V, S> = unsafe { util::change_lifetime_const(&*guard) };
         let iter = sref.iter();
         self.current = Some((Arc::new(guard), iter));
         self.shard_i += 1;
@@ -88,30 +96,37 @@ impl<'a, K: Eq + Hash, V, M: Map<'a, K, V>> Iterator for Iter<'a, K, V, M> {
 /// map.iter_mut().for_each(|mut r| *r += 1);
 /// assert_eq!(*map.get("Johnny").unwrap(), 22);
 /// ```
-pub struct IterMut<'a, K: Eq + Hash, V, M: Map<'a, K, V>> {
+pub struct IterMut<'a, K: Eq + Hash, V, S: 'a + BuildHasher, M: Map<'a, K, V, S>> {
     map: &'a M,
     shard_i: usize,
-    current: Option<GuardIterMut<'a, K, V>>,
+    current: Option<GuardIterMut<'a, K, V, S>>,
+    phantom: PhantomData<S>,
 }
 
-unsafe impl<'a, K: Eq + Hash + Send, V: Send, M: Map<'a, K, V>> Send for IterMut<'a, K, V, M> {}
-unsafe impl<'a, K: Eq + Hash + Send + Sync, V: Send + Sync, M: Map<'a, K, V>> Sync
-    for IterMut<'a, K, V, M>
+unsafe impl<'a, K: Eq + Hash + Send, V: Send, S: 'a + BuildHasher, M: Map<'a, K, V, S>> Send
+    for IterMut<'a, K, V, S, M>
+{
+}
+unsafe impl<'a, K: Eq + Hash + Send + Sync, V: Send + Sync, S: 'a + BuildHasher, M: Map<'a, K, V, S>>
+    Sync for IterMut<'a, K, V, S, M>
 {
 }
 
-impl<'a, K: Eq + Hash, V, M: Map<'a, K, V>> IterMut<'a, K, V, M> {
+impl<'a, K: Eq + Hash, V, S: 'a + BuildHasher, M: Map<'a, K, V, S>> IterMut<'a, K, V, S, M> {
     pub(crate) fn new(map: &'a M) -> Self {
         Self {
             map,
             shard_i: 0,
             current: None,
+            phantom: PhantomData,
         }
     }
 }
 
-impl<'a, K: Eq + Hash, V, M: Map<'a, K, V>> Iterator for IterMut<'a, K, V, M> {
-    type Item = RefMutMulti<'a, K, V>;
+impl<'a, K: Eq + Hash, V, S: 'a + BuildHasher, M: Map<'a, K, V, S>> Iterator
+    for IterMut<'a, K, V, S, M>
+{
+    type Item = RefMutMulti<'a, K, V, S>;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -131,7 +146,7 @@ impl<'a, K: Eq + Hash, V, M: Map<'a, K, V>> Iterator for IterMut<'a, K, V, M> {
         }
 
         let mut guard = unsafe { self.map._yield_write_shard(self.shard_i) };
-        let sref: &mut HashMap<K, V> = unsafe { util::change_lifetime_mut(&mut *guard) };
+        let sref: &mut HashMap<K, V, S> = unsafe { util::change_lifetime_mut(&mut *guard) };
         let iter = sref.iter_mut();
         self.current = Some((Arc::new(guard), iter));
         self.shard_i += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use mapref::entry::{Entry, OccupiedEntry, VacantEntry};
 use mapref::one::{Ref, RefMut};
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::borrow::Borrow;
-use std::hash::Hash;
+use std::hash::{BuildHasher, Hash};
 use std::iter::FromIterator;
 use std::ops::{BitAnd, BitOr, Shl, Shr, Sub};
 use t::Map;
@@ -28,7 +28,7 @@ cfg_if! {
     }
 }
 
-type HashMap<K, V> = std::collections::HashMap<K, SharedValue<V>, FxBuildHasher>;
+type HashMap<K, V, S> = std::collections::HashMap<K, SharedValue<V>, S>;
 
 fn shard_amount() -> usize {
     (num_cpus::get() * 4).next_power_of_two()
@@ -47,15 +47,16 @@ fn ncb(shard_amount: usize) -> usize {
 /// To accomplish these all methods take `&self` instead modifying methods taking `&mut self`.
 /// This allows you to put a DashMap in an `Arc<T>` and share it between threads while being able to modify it.
 #[derive(Default)]
-pub struct DashMap<K, V>
+pub struct DashMap<K, V, S = FxBuildHasher>
 where
     K: Eq + Hash,
+    S: BuildHasher,
 {
     ncb: usize,
-    shards: Box<[RwLock<HashMap<K, V>>]>,
+    shards: Box<[RwLock<HashMap<K, V, S>>]>,
 }
 
-impl<'a, K: 'a + Eq + Hash, V: 'a> DashMap<K, V> {
+impl<'a, K: 'a + Eq + Hash, V: 'a> DashMap<K, V, FxBuildHasher> {
     /// Creates a new DashMap with a capacity of 0.
     ///
     /// # Examples
@@ -110,6 +111,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a> DashMap<K, V> {
             shards,
         }
     }
+}
 
     cfg_if! {
         if #[cfg(feature = "raw-api")] {
@@ -127,13 +129,13 @@ impl<'a, K: 'a + Eq + Hash, V: 'a> DashMap<K, V> {
             /// println!("Amount of shards: {}", map.shards().len());
             /// ```
             #[inline]
-            pub fn shards(&self) -> &[RwLock<HashMap<K, V>>] {
+            pub fn shards(&self) -> &[RwLock<HashMap<K, V, S>>] {
                 &self.shards
             }
         } else {
             #[allow(dead_code)]
             #[inline]
-            fn shards(&self) -> &[RwLock<HashMap<K, V>>] {
+            fn shards(&self) -> &[RwLock<HashMap<K, V, S>>] {
                 &self.shards
             }
         }
@@ -228,7 +230,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a> DashMap<K, V> {
     /// assert_eq!(words.iter().count(), 1);
     /// ```
     #[inline]
-    pub fn iter(&'a self) -> Iter<'a, K, V, DashMap<K, V>> {
+    pub fn iter(&'a self) -> Iter<'a, K, V, S, DashMap<K, V, S>> {
         self._iter()
     }
 
@@ -245,7 +247,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a> DashMap<K, V> {
     /// assert_eq!(*map.get("Johnny").unwrap(), 22);
     /// ```
     #[inline]
-    pub fn iter_mut(&'a self) -> IterMut<'a, K, V, DashMap<K, V>> {
+    pub fn iter_mut(&'a self) -> IterMut<'a, K, V, S, DashMap<K, V, S>> {
         self._iter_mut()
     }
 
@@ -261,7 +263,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a> DashMap<K, V> {
     /// assert_eq!(*youtubers.get("Bosnian Bill").unwrap(), 457000);
     /// ```
     #[inline]
-    pub fn get<Q>(&'a self, key: &Q) -> Option<Ref<'a, K, V>>
+    pub fn get<Q>(&'a self, key: &Q) -> Option<Ref<'a, K, V, S>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
@@ -282,7 +284,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a> DashMap<K, V> {
     /// assert_eq!(*class.get("Albin").unwrap(), 14);
     /// ```
     #[inline]
-    pub fn get_mut<Q>(&'a self, key: &Q) -> Option<RefMut<'a, K, V>>
+    pub fn get_mut<Q>(&'a self, key: &Q) -> Option<RefMut<'a, K, V, S>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
@@ -444,25 +446,25 @@ impl<'a, K: 'a + Eq + Hash, V: 'a> DashMap<K, V> {
     /// Advanced entry API that tries to mimic `std::collections::HashMap`.
     /// See the documentation on `dashmap::mapref::entry` for more details.
     #[inline]
-    pub fn entry(&'a self, key: K) -> Entry<'a, K, V> {
+    pub fn entry(&'a self, key: K) -> Entry<'a, K, V, S> {
         self._entry(key)
     }
 }
 
-impl<'a, K: 'a + Eq + Hash, V: 'a> Map<'a, K, V> for DashMap<K, V> {
+impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher> Map<'a, K, V, S> for DashMap<K, V, S> {
     #[inline]
     fn _shard_count(&self) -> usize {
         self.shards.len()
     }
 
     #[inline]
-    unsafe fn _yield_read_shard(&'a self, i: usize) -> RwLockReadGuard<'a, HashMap<K, V>> {
+    unsafe fn _yield_read_shard(&'a self, i: usize) -> RwLockReadGuard<'a, HashMap<K, V, S>> {
         debug_assert!(i < self.shards.len());
         self.shards.get_unchecked(i).read()
     }
 
     #[inline]
-    unsafe fn _yield_write_shard(&'a self, i: usize) -> RwLockWriteGuard<'a, HashMap<K, V>> {
+    unsafe fn _yield_write_shard(&'a self, i: usize) -> RwLockWriteGuard<'a, HashMap<K, V, S>> {
         debug_assert!(i < self.shards.len());
         self.shards.get_unchecked(i).write()
     }
@@ -488,17 +490,17 @@ impl<'a, K: 'a + Eq + Hash, V: 'a> Map<'a, K, V> for DashMap<K, V> {
     }
 
     #[inline]
-    fn _iter(&'a self) -> Iter<'a, K, V, DashMap<K, V>> {
+    fn _iter(&'a self) -> Iter<'a, K, V, S, DashMap<K, V, S>> {
         Iter::new(self)
     }
 
     #[inline]
-    fn _iter_mut(&'a self) -> IterMut<'a, K, V, DashMap<K, V>> {
+    fn _iter_mut(&'a self) -> IterMut<'a, K, V, S, DashMap<K, V, S>> {
         IterMut::new(self)
     }
 
     #[inline]
-    fn _get<Q>(&'a self, key: &Q) -> Option<Ref<'a, K, V>>
+    fn _get<Q>(&'a self, key: &Q) -> Option<Ref<'a, K, V, S>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
@@ -517,7 +519,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a> Map<'a, K, V> for DashMap<K, V> {
     }
 
     #[inline]
-    fn _get_mut<Q>(&'a self, key: &Q) -> Option<RefMut<'a, K, V>>
+    fn _get_mut<Q>(&'a self, key: &Q) -> Option<RefMut<'a, K, V, S>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
@@ -578,7 +580,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a> Map<'a, K, V> for DashMap<K, V> {
     }
 
     #[inline]
-    fn _entry(&'a self, key: K) -> Entry<'a, K, V> {
+    fn _entry(&'a self, key: K) -> Entry<'a, K, V, S> {
         let idx = self.determine_map(&key);
         let shard = unsafe { self._yield_write_shard(idx) };
         if let Some((kptr, vptr)) = shard.get_key_value(&key) {
@@ -593,7 +595,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a> Map<'a, K, V> for DashMap<K, V> {
     }
 }
 
-impl<'a, K: 'a + Eq + Hash, V: 'a> Shl<(K, V)> for &'a DashMap<K, V> {
+impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher> Shl<(K, V)> for &'a DashMap<K, V, S> {
     type Output = Option<V>;
 
     #[inline]
@@ -602,12 +604,12 @@ impl<'a, K: 'a + Eq + Hash, V: 'a> Shl<(K, V)> for &'a DashMap<K, V> {
     }
 }
 
-impl<'a, K: 'a + Eq + Hash, V: 'a, Q> Shr<&Q> for &'a DashMap<K, V>
+impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher, Q> Shr<&Q> for &'a DashMap<K, V, S>
 where
     K: Borrow<Q>,
     Q: Hash + Eq + ?Sized,
 {
-    type Output = Ref<'a, K, V>;
+    type Output = Ref<'a, K, V, S>;
 
     #[inline]
     fn shr(self, key: &Q) -> Self::Output {
@@ -615,12 +617,12 @@ where
     }
 }
 
-impl<'a, K: 'a + Eq + Hash, V: 'a, Q> BitOr<&Q> for &'a DashMap<K, V>
+impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher, Q> BitOr<&Q> for &'a DashMap<K, V, S>
 where
     K: Borrow<Q>,
     Q: Hash + Eq + ?Sized,
 {
-    type Output = RefMut<'a, K, V>;
+    type Output = RefMut<'a, K, V, S>;
 
     #[inline]
     fn bitor(self, key: &Q) -> Self::Output {
@@ -628,7 +630,7 @@ where
     }
 }
 
-impl<'a, K: 'a + Eq + Hash, V: 'a, Q> Sub<&Q> for &'a DashMap<K, V>
+impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher, Q> Sub<&Q> for &'a DashMap<K, V, S>
 where
     K: Borrow<Q>,
     Q: Hash + Eq + ?Sized,
@@ -641,7 +643,7 @@ where
     }
 }
 
-impl<'a, K: 'a + Eq + Hash, V: 'a, Q> BitAnd<&Q> for &'a DashMap<K, V>
+impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher, Q> BitAnd<&Q> for &'a DashMap<K, V, S>
 where
     K: Borrow<Q>,
     Q: Hash + Eq + ?Sized,
@@ -654,7 +656,7 @@ where
     }
 }
 
-impl<K: Eq + Hash, V> Extend<(K, V)> for DashMap<K, V> {
+impl<K: Eq + Hash, V, S: BuildHasher> Extend<(K, V)> for DashMap<K, V, S> {
     fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, intoiter: I) {
         for pair in intoiter.into_iter() {
             self.insert(pair.0, pair.1);
@@ -662,7 +664,7 @@ impl<K: Eq + Hash, V> Extend<(K, V)> for DashMap<K, V> {
     }
 }
 
-impl<K: Eq + Hash, V> FromIterator<(K, V)> for DashMap<K, V> {
+impl<K: Eq + Hash, V> FromIterator<(K, V)> for DashMap<K, V, FxBuildHasher> {
     fn from_iter<I: IntoIterator<Item = (K, V)>>(intoiter: I) -> Self {
         let mut map = DashMap::new();
         map.extend(intoiter);

--- a/src/mapref/entry.rs
+++ b/src/mapref/entry.rs
@@ -3,16 +3,16 @@ use crate::util;
 use crate::util::SharedValue;
 use crate::HashMap;
 use parking_lot::RwLockWriteGuard;
-use std::hash::Hash;
+use std::hash::{BuildHasher, Hash};
 use std::mem;
 use std::ptr;
 
-pub enum Entry<'a, K: Eq + Hash, V> {
-    Occupied(OccupiedEntry<'a, K, V>),
-    Vacant(VacantEntry<'a, K, V>),
+pub enum Entry<'a, K: Eq + Hash, V, S: BuildHasher> {
+    Occupied(OccupiedEntry<'a, K, V, S>),
+    Vacant(VacantEntry<'a, K, V, S>),
 }
 
-impl<'a, K: Eq + Hash, V> Entry<'a, K, V> {
+impl<'a, K: Eq + Hash, V, S: BuildHasher> Entry<'a, K, V, S> {
     /// Apply a function to the stored value if it exists.
     #[inline]
     pub fn and_modify(self, f: impl FnOnce(&mut V)) -> Self {
@@ -38,7 +38,7 @@ impl<'a, K: Eq + Hash, V> Entry<'a, K, V> {
     /// Return a mutable reference to the element if it exists,
     /// otherwise insert the default and return a mutable reference to that.
     #[inline]
-    pub fn or_default(self) -> RefMut<'a, K, V>
+    pub fn or_default(self) -> RefMut<'a, K, V, S>
     where
         V: Default,
     {
@@ -51,7 +51,7 @@ impl<'a, K: Eq + Hash, V> Entry<'a, K, V> {
     /// Return a mutable reference to the element if it exists,
     /// otherwise a provided value and return a mutable reference to that.
     #[inline]
-    pub fn or_insert(self, value: V) -> RefMut<'a, K, V> {
+    pub fn or_insert(self, value: V) -> RefMut<'a, K, V, S> {
         match self {
             Entry::Occupied(entry) => entry.into_ref(),
             Entry::Vacant(entry) => entry.insert(value),
@@ -61,7 +61,7 @@ impl<'a, K: Eq + Hash, V> Entry<'a, K, V> {
     /// Return a mutable reference to the element if it exists,
     /// otherwise insert the result of a provided function and return a mutable reference to that.
     #[inline]
-    pub fn or_insert_with(self, value: impl FnOnce() -> V) -> RefMut<'a, K, V> {
+    pub fn or_insert_with(self, value: impl FnOnce() -> V) -> RefMut<'a, K, V, S> {
         match self {
             Entry::Occupied(entry) => entry.into_ref(),
             Entry::Vacant(entry) => entry.insert(value()),
@@ -69,22 +69,25 @@ impl<'a, K: Eq + Hash, V> Entry<'a, K, V> {
     }
 }
 
-pub struct VacantEntry<'a, K: Eq + Hash, V> {
-    shard: RwLockWriteGuard<'a, HashMap<K, V>>,
+pub struct VacantEntry<'a, K: Eq + Hash, V, S> {
+    shard: RwLockWriteGuard<'a, HashMap<K, V, S>>,
     key: K,
 }
 
-unsafe impl<'a, K: Eq + Hash + Send, V: Send> Send for VacantEntry<'a, K, V> {}
-unsafe impl<'a, K: Eq + Hash + Send + Sync, V: Send + Sync> Sync for VacantEntry<'a, K, V> {}
+unsafe impl<'a, K: Eq + Hash + Send, V: Send, S: BuildHasher> Send for VacantEntry<'a, K, V, S> {}
+unsafe impl<'a, K: Eq + Hash + Send + Sync, V: Send + Sync, S: BuildHasher> Sync
+    for VacantEntry<'a, K, V, S>
+{
+}
 
-impl<'a, K: Eq + Hash, V> VacantEntry<'a, K, V> {
+impl<'a, K: Eq + Hash, V, S: BuildHasher> VacantEntry<'a, K, V, S> {
     #[inline]
-    pub(crate) fn new(shard: RwLockWriteGuard<'a, HashMap<K, V>>, key: K) -> Self {
+    pub(crate) fn new(shard: RwLockWriteGuard<'a, HashMap<K, V, S>>, key: K) -> Self {
         Self { shard, key }
     }
 
     #[inline]
-    pub fn insert(mut self, value: V) -> RefMut<'a, K, V> {
+    pub fn insert(mut self, value: V) -> RefMut<'a, K, V, S> {
         unsafe {
             let c: K = ptr::read(&self.key);
             self.shard.insert(self.key, SharedValue::new(value));
@@ -108,19 +111,22 @@ impl<'a, K: Eq + Hash, V> VacantEntry<'a, K, V> {
     }
 }
 
-pub struct OccupiedEntry<'a, K: Eq + Hash, V> {
-    shard: RwLockWriteGuard<'a, HashMap<K, V>>,
+pub struct OccupiedEntry<'a, K: Eq + Hash, V, S: BuildHasher> {
+    shard: RwLockWriteGuard<'a, HashMap<K, V, S>>,
     elem: (&'a K, &'a mut V),
     key: Option<K>,
 }
 
-unsafe impl<'a, K: Eq + Hash + Send, V: Send> Send for OccupiedEntry<'a, K, V> {}
-unsafe impl<'a, K: Eq + Hash + Send + Sync, V: Send + Sync> Sync for OccupiedEntry<'a, K, V> {}
+unsafe impl<'a, K: Eq + Hash + Send, V: Send, S: BuildHasher> Send for OccupiedEntry<'a, K, V, S> {}
+unsafe impl<'a, K: Eq + Hash + Send + Sync, V: Send + Sync, S: BuildHasher> Sync
+    for OccupiedEntry<'a, K, V, S>
+{
+}
 
-impl<'a, K: Eq + Hash, V> OccupiedEntry<'a, K, V> {
+impl<'a, K: Eq + Hash, V, S: BuildHasher> OccupiedEntry<'a, K, V, S> {
     #[inline]
     pub(crate) fn new(
-        shard: RwLockWriteGuard<'a, HashMap<K, V>>,
+        shard: RwLockWriteGuard<'a, HashMap<K, V, S>>,
         key: Option<K>,
         elem: (&'a K, &'a mut V),
     ) -> Self {
@@ -143,7 +149,7 @@ impl<'a, K: Eq + Hash, V> OccupiedEntry<'a, K, V> {
     }
 
     #[inline]
-    pub fn into_ref(self) -> RefMut<'a, K, V> {
+    pub fn into_ref(self) -> RefMut<'a, K, V, S> {
         RefMut::new(self.shard, self.elem.0, self.elem.1)
     }
 

--- a/src/mapref/multiple.rs
+++ b/src/mapref/multiple.rs
@@ -6,18 +6,22 @@ use std::sync::Arc;
 
 // -- Shared
 
-pub struct RefMulti<'a, K: Eq + Hash, V> {
-    _guard: Arc<RwLockReadGuard<'a, HashMap<K, V>>>,
+pub struct RefMulti<'a, K: Eq + Hash, V, S> {
+    _guard: Arc<RwLockReadGuard<'a, HashMap<K, V, S>>>,
     k: &'a K,
     v: &'a V,
 }
 
-unsafe impl<'a, K: Eq + Hash + Send, V: Send> Send for RefMulti<'a, K, V> {}
-unsafe impl<'a, K: Eq + Hash + Send + Sync, V: Send + Sync> Sync for RefMulti<'a, K, V> {}
+unsafe impl<'a, K: Eq + Hash + Send, V: Send, S> Send for RefMulti<'a, K, V, S> {}
+unsafe impl<'a, K: Eq + Hash + Send + Sync, V: Send + Sync, S> Sync for RefMulti<'a, K, V, S> {}
 
-impl<'a, K: Eq + Hash, V> RefMulti<'a, K, V> {
+impl<'a, K: Eq + Hash, V, S> RefMulti<'a, K, V, S> {
     #[inline(always)]
-    pub(crate) fn new(guard: Arc<RwLockReadGuard<'a, HashMap<K, V>>>, k: &'a K, v: &'a V) -> Self {
+    pub(crate) fn new(
+        guard: Arc<RwLockReadGuard<'a, HashMap<K, V, S>>>,
+        k: &'a K,
+        v: &'a V,
+    ) -> Self {
         Self {
             _guard: guard,
             k,
@@ -41,7 +45,7 @@ impl<'a, K: Eq + Hash, V> RefMulti<'a, K, V> {
     }
 }
 
-impl<'a, K: Eq + Hash, V> Deref for RefMulti<'a, K, V> {
+impl<'a, K: Eq + Hash, V, S> Deref for RefMulti<'a, K, V, S> {
     type Target = V;
 
     #[inline(always)]
@@ -54,19 +58,19 @@ impl<'a, K: Eq + Hash, V> Deref for RefMulti<'a, K, V> {
 
 // -- Unique
 
-pub struct RefMutMulti<'a, K: Eq + Hash, V> {
-    _guard: Arc<RwLockWriteGuard<'a, HashMap<K, V>>>,
+pub struct RefMutMulti<'a, K: Eq + Hash, V, S> {
+    _guard: Arc<RwLockWriteGuard<'a, HashMap<K, V, S>>>,
     k: &'a K,
     v: &'a mut V,
 }
 
-unsafe impl<'a, K: Eq + Hash + Send, V: Send> Send for RefMutMulti<'a, K, V> {}
-unsafe impl<'a, K: Eq + Hash + Send + Sync, V: Send + Sync> Sync for RefMutMulti<'a, K, V> {}
+unsafe impl<'a, K: Eq + Hash + Send, V: Send, S> Send for RefMutMulti<'a, K, V, S> {}
+unsafe impl<'a, K: Eq + Hash + Send + Sync, V: Send + Sync, S> Sync for RefMutMulti<'a, K, V, S> {}
 
-impl<'a, K: Eq + Hash, V> RefMutMulti<'a, K, V> {
+impl<'a, K: Eq + Hash, V, S> RefMutMulti<'a, K, V, S> {
     #[inline(always)]
     pub(crate) fn new(
-        guard: Arc<RwLockWriteGuard<'a, HashMap<K, V>>>,
+        guard: Arc<RwLockWriteGuard<'a, HashMap<K, V, S>>>,
         k: &'a K,
         v: &'a mut V,
     ) -> Self {
@@ -103,7 +107,7 @@ impl<'a, K: Eq + Hash, V> RefMutMulti<'a, K, V> {
     }
 }
 
-impl<'a, K: Eq + Hash, V> Deref for RefMutMulti<'a, K, V> {
+impl<'a, K: Eq + Hash, V, S> Deref for RefMutMulti<'a, K, V, S> {
     type Target = V;
 
     #[inline(always)]
@@ -112,7 +116,7 @@ impl<'a, K: Eq + Hash, V> Deref for RefMutMulti<'a, K, V> {
     }
 }
 
-impl<'a, K: Eq + Hash, V> DerefMut for RefMutMulti<'a, K, V> {
+impl<'a, K: Eq + Hash, V, S> DerefMut for RefMutMulti<'a, K, V, S> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut V {
         self.value_mut()

--- a/src/t.rs
+++ b/src/t.rs
@@ -6,28 +6,28 @@ use crate::mapref::one::{Ref, RefMut};
 use crate::HashMap;
 use parking_lot::{RwLockReadGuard, RwLockWriteGuard};
 use std::borrow::Borrow;
-use std::hash::Hash;
+use std::hash::{BuildHasher, Hash};
 
-pub trait Map<'a, K: 'a + Eq + Hash, V: 'a> {
+pub trait Map<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher> {
     fn _shard_count(&self) -> usize;
-    unsafe fn _yield_read_shard(&'a self, i: usize) -> RwLockReadGuard<'a, HashMap<K, V>>;
-    unsafe fn _yield_write_shard(&'a self, i: usize) -> RwLockWriteGuard<'a, HashMap<K, V>>;
+    unsafe fn _yield_read_shard(&'a self, i: usize) -> RwLockReadGuard<'a, HashMap<K, V, S>>;
+    unsafe fn _yield_write_shard(&'a self, i: usize) -> RwLockWriteGuard<'a, HashMap<K, V, S>>;
     fn _insert(&self, key: K, value: V) -> Option<V>;
     fn _remove<Q>(&self, key: &Q) -> Option<(K, V)>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized;
-    fn _iter(&'a self) -> Iter<'a, K, V, Self>
+    fn _iter(&'a self) -> Iter<'a, K, V, S, Self>
     where
         Self: Sized;
-    fn _iter_mut(&'a self) -> IterMut<'a, K, V, Self>
+    fn _iter_mut(&'a self) -> IterMut<'a, K, V, S, Self>
     where
         Self: Sized;
-    fn _get<Q>(&'a self, key: &Q) -> Option<Ref<'a, K, V>>
+    fn _get<Q>(&'a self, key: &Q) -> Option<Ref<'a, K, V, S>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized;
-    fn _get_mut<Q>(&'a self, key: &Q) -> Option<RefMut<'a, K, V>>
+    fn _get_mut<Q>(&'a self, key: &Q) -> Option<RefMut<'a, K, V, S>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized;
@@ -40,7 +40,7 @@ pub trait Map<'a, K: 'a + Eq + Hash, V: 'a> {
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized;
     fn _alter_all(&self, f: impl FnMut(&K, V) -> V);
-    fn _entry(&'a self, key: K) -> Entry<'a, K, V>;
+    fn _entry(&'a self, key: K) -> Entry<'a, K, V, S>;
 
     // provided
 


### PR DESCRIPTION
This is my attempt at adding `with_hasher` and `with_capacity_and_hasher` to `DashMap`. 

It unfortunately is rather invasive, as `HashMap<K, V>` needs to be changed to `HashMap<K, V, S>`, and `HashMap` is referenced all over the place. I could probably remove some `BuildHasher` bounds if you think that is cleaner.

Oh and if you want it should be easy to switch to SipHash (#12), but perhaps that should be a major version bump...