### PR TITLE
Some minor improvements.

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -6,7 +6,6 @@ use crate::HashMap;
 use parking_lot::{RwLockReadGuard, RwLockWriteGuard};
 use std::collections::hash_map;
 use std::hash::{BuildHasher, Hash};
-use std::marker::PhantomData;
 use std::sync::Arc;
 
 type GuardIter<'a, K, V, S> = (
@@ -33,7 +32,6 @@ pub struct Iter<'a, K: Eq + Hash, V, S: 'a + BuildHasher, M: Map<'a, K, V, S>> {
     map: &'a M,
     shard_i: usize,
     current: Option<GuardIter<'a, K, V, S>>,
-    phantom: PhantomData<S>,
 }
 
 unsafe impl<'a, K: Eq + Hash + Send, V: Send, S: 'a + BuildHasher, M: Map<'a, K, V, S>> Send
@@ -51,7 +49,6 @@ impl<'a, K: Eq + Hash, V, S: 'a + BuildHasher, M: Map<'a, K, V, S>> Iter<'a, K, 
             map,
             shard_i: 0,
             current: None,
-            phantom: PhantomData,
         }
     }
 }
@@ -100,7 +97,6 @@ pub struct IterMut<'a, K: Eq + Hash, V, S: 'a + BuildHasher, M: Map<'a, K, V, S>
     map: &'a M,
     shard_i: usize,
     current: Option<GuardIterMut<'a, K, V, S>>,
-    phantom: PhantomData<S>,
 }
 
 unsafe impl<'a, K: Eq + Hash + Send, V: Send, S: 'a + BuildHasher, M: Map<'a, K, V, S>> Send
@@ -118,7 +114,6 @@ impl<'a, K: Eq + Hash, V, S: 'a + BuildHasher, M: Map<'a, K, V, S>> IterMut<'a, 
             map,
             shard_i: 0,
             current: None,
-            phantom: PhantomData,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ fn shard_amount() -> usize {
 
 #[inline]
 fn ncb(shard_amount: usize) -> usize {
-    (shard_amount as f32).log2() as usize
+    shard_amount.trailing_zeros() as usize
 }
 
 /// DashMap is an implementation of a concurrent associative array/hashmap in Rust.
@@ -119,8 +119,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
         let shard_amount = shard_amount();
         let shards = (0..shard_amount)
             .map(|_| RwLock::new(HashMap::with_hasher(hasher.clone())))
-            .collect::<Vec<_>>()
-            .into_boxed_slice();
+            .collect();
 
         Self {
             ncb: ncb(shard_amount),
@@ -147,8 +146,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
         let cps = capacity / shard_amount;
         let shards = (0..shard_amount)
             .map(|_| RwLock::new(HashMap::with_capacity_and_hasher(cps, hasher.clone())))
-            .collect::<Vec<_>>()
-            .into_boxed_slice();
+            .collect();
 
         Self {
             ncb: ncb(shard_amount),

--- a/src/mapref/one.rs
+++ b/src/mapref/one.rs
@@ -2,7 +2,6 @@ use crate::HashMap;
 use fxhash::FxBuildHasher;
 use parking_lot::{RwLockReadGuard, RwLockWriteGuard};
 use std::hash::{BuildHasher, Hash};
-use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 
 // -- Shared
@@ -11,7 +10,6 @@ pub struct Ref<'a, K: Eq + Hash, V, S: BuildHasher = FxBuildHasher> {
     _guard: RwLockReadGuard<'a, HashMap<K, V, S>>,
     k: &'a K,
     v: &'a V,
-    phantom: PhantomData<S>,
 }
 
 unsafe impl<'a, K: Eq + Hash + Send, V: Send, S: BuildHasher> Send for Ref<'a, K, V, S> {}
@@ -27,7 +25,6 @@ impl<'a, K: Eq + Hash, V, S: BuildHasher> Ref<'a, K, V, S> {
             _guard: guard,
             k,
             v,
-            phantom: PhantomData,
         }
     }
 


### PR DESCRIPTION
I removed some unnecessary PhanomDatas and some unnecessary creations of Vecs. I also replaced `(shard_amount as f32).log2() as usize` with `shard_amount.trailing_zeros() as usize`, which is probably much faster because it assumes that `shard_amount` is always a power of two, which it is.