### PR TITLE
Removed UB `Send`/`Sync` bounds

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -28,19 +28,10 @@ type GuardIterMut<'a, K, V, S> = (
 /// map.insert("hello", "world");
 /// assert_eq!(map.iter().count(), 1);
 /// ```
-pub struct Iter<'a, K: Eq + Hash, V, S: 'a + BuildHasher, M: Map<'a, K, V, S>> {
+pub struct Iter<'a, K, V, S, M> {
     map: &'a M,
     shard_i: usize,
     current: Option<GuardIter<'a, K, V, S>>,
-}
-
-unsafe impl<'a, K: Eq + Hash + Send, V: Send, S: 'a + BuildHasher, M: Map<'a, K, V, S>> Send
-    for Iter<'a, K, V, S, M>
-{
-}
-unsafe impl<'a, K: Eq + Hash + Send + Sync, V: Send + Sync, S: 'a + BuildHasher, M: Map<'a, K, V, S>>
-    Sync for Iter<'a, K, V, S, M>
-{
 }
 
 impl<'a, K: Eq + Hash, V, S: 'a + BuildHasher, M: Map<'a, K, V, S>> Iter<'a, K, V, S, M> {
@@ -93,19 +84,10 @@ impl<'a, K: Eq + Hash, V, S: 'a + BuildHasher, M: Map<'a, K, V, S>> Iterator
 /// map.iter_mut().for_each(|mut r| *r += 1);
 /// assert_eq!(*map.get("Johnny").unwrap(), 22);
 /// ```
-pub struct IterMut<'a, K: Eq + Hash, V, S: 'a + BuildHasher, M: Map<'a, K, V, S>> {
+pub struct IterMut<'a, K, V, S, M> {
     map: &'a M,
     shard_i: usize,
     current: Option<GuardIterMut<'a, K, V, S>>,
-}
-
-unsafe impl<'a, K: Eq + Hash + Send, V: Send, S: 'a + BuildHasher, M: Map<'a, K, V, S>> Send
-    for IterMut<'a, K, V, S, M>
-{
-}
-unsafe impl<'a, K: Eq + Hash + Send + Sync, V: Send + Sync, S: 'a + BuildHasher, M: Map<'a, K, V, S>>
-    Sync for IterMut<'a, K, V, S, M>
-{
 }
 
 impl<'a, K: Eq + Hash, V, S: 'a + BuildHasher, M: Map<'a, K, V, S>> IterMut<'a, K, V, S, M> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,11 +50,7 @@ fn ncb(shard_amount: usize) -> usize {
 /// DashMap tries to be very simple to use and to be a direct replacement for `RwLock<HashMap<K, V>>`.
 /// To accomplish these all methods take `&self` instead modifying methods taking `&mut self`.
 /// This allows you to put a DashMap in an `Arc<T>` and share it between threads while being able to modify it.
-pub struct DashMap<K, V, S = FxBuildHasher>
-where
-    K: Eq + Hash,
-    S: BuildHasher + Clone,
-{
+pub struct DashMap<K, V, S = FxBuildHasher> {
     ncb: usize,
     shards: Box<[RwLock<HashMap<K, V, S>>]>,
 }

--- a/src/mapref/entry.rs
+++ b/src/mapref/entry.rs
@@ -8,7 +8,7 @@ use std::hash::{BuildHasher, Hash};
 use std::mem;
 use std::ptr;
 
-pub enum Entry<'a, K: Eq + Hash, V, S: BuildHasher = FxBuildHasher> {
+pub enum Entry<'a, K, V, S = FxBuildHasher> {
     Occupied(OccupiedEntry<'a, K, V, S>),
     Vacant(VacantEntry<'a, K, V, S>),
 }
@@ -70,15 +70,9 @@ impl<'a, K: Eq + Hash, V, S: BuildHasher> Entry<'a, K, V, S> {
     }
 }
 
-pub struct VacantEntry<'a, K: Eq + Hash, V, S> {
+pub struct VacantEntry<'a, K, V, S> {
     shard: RwLockWriteGuard<'a, HashMap<K, V, S>>,
     key: K,
-}
-
-unsafe impl<'a, K: Eq + Hash + Send, V: Send, S: BuildHasher> Send for VacantEntry<'a, K, V, S> {}
-unsafe impl<'a, K: Eq + Hash + Send + Sync, V: Send + Sync, S: BuildHasher> Sync
-    for VacantEntry<'a, K, V, S>
-{
 }
 
 impl<'a, K: Eq + Hash, V, S: BuildHasher> VacantEntry<'a, K, V, S> {
@@ -112,16 +106,10 @@ impl<'a, K: Eq + Hash, V, S: BuildHasher> VacantEntry<'a, K, V, S> {
     }
 }
 
-pub struct OccupiedEntry<'a, K: Eq + Hash, V, S: BuildHasher> {
+pub struct OccupiedEntry<'a, K, V, S> {
     shard: RwLockWriteGuard<'a, HashMap<K, V, S>>,
     elem: (&'a K, &'a mut V),
     key: Option<K>,
-}
-
-unsafe impl<'a, K: Eq + Hash + Send, V: Send, S: BuildHasher> Send for OccupiedEntry<'a, K, V, S> {}
-unsafe impl<'a, K: Eq + Hash + Send + Sync, V: Send + Sync, S: BuildHasher> Sync
-    for OccupiedEntry<'a, K, V, S>
-{
 }
 
 impl<'a, K: Eq + Hash, V, S: BuildHasher> OccupiedEntry<'a, K, V, S> {

--- a/src/mapref/multiple.rs
+++ b/src/mapref/multiple.rs
@@ -8,16 +8,10 @@ use std::sync::Arc;
 
 // -- Shared
 
-pub struct RefMulti<'a, K: Eq + Hash, V, S: BuildHasher = FxBuildHasher> {
+pub struct RefMulti<'a, K, V, S = FxBuildHasher> {
     _guard: Arc<RwLockReadGuard<'a, HashMap<K, V, S>>>,
     k: &'a K,
     v: &'a V,
-}
-
-unsafe impl<'a, K: Eq + Hash + Send, V: Send, S: BuildHasher> Send for RefMulti<'a, K, V, S> {}
-unsafe impl<'a, K: Eq + Hash + Send + Sync, V: Send + Sync, S: BuildHasher> Sync
-    for RefMulti<'a, K, V, S>
-{
 }
 
 impl<'a, K: Eq + Hash, V, S: BuildHasher> RefMulti<'a, K, V, S> {
@@ -63,16 +57,10 @@ impl<'a, K: Eq + Hash, V, S: BuildHasher> Deref for RefMulti<'a, K, V, S> {
 
 // -- Unique
 
-pub struct RefMutMulti<'a, K: Eq + Hash, V, S: BuildHasher = FxBuildHasher> {
+pub struct RefMutMulti<'a, K, V, S = FxBuildHasher> {
     _guard: Arc<RwLockWriteGuard<'a, HashMap<K, V, S>>>,
     k: &'a K,
     v: &'a mut V,
-}
-
-unsafe impl<'a, K: Eq + Hash + Send, V: Send, S: BuildHasher> Send for RefMutMulti<'a, K, V, S> {}
-unsafe impl<'a, K: Eq + Hash + Send + Sync, V: Send + Sync, S: BuildHasher> Sync
-    for RefMutMulti<'a, K, V, S>
-{
 }
 
 impl<'a, K: Eq + Hash, V, S: BuildHasher> RefMutMulti<'a, K, V, S> {

--- a/src/mapref/one.rs
+++ b/src/mapref/one.rs
@@ -6,16 +6,10 @@ use std::ops::{Deref, DerefMut};
 
 // -- Shared
 
-pub struct Ref<'a, K: Eq + Hash, V, S: BuildHasher = FxBuildHasher> {
+pub struct Ref<'a, K, V, S = FxBuildHasher> {
     _guard: RwLockReadGuard<'a, HashMap<K, V, S>>,
     k: &'a K,
     v: &'a V,
-}
-
-unsafe impl<'a, K: Eq + Hash + Send, V: Send, S: BuildHasher> Send for Ref<'a, K, V, S> {}
-unsafe impl<'a, K: Eq + Hash + Send + Sync, V: Send + Sync, S: BuildHasher> Sync
-    for Ref<'a, K, V, S>
-{
 }
 
 impl<'a, K: Eq + Hash, V, S: BuildHasher> Ref<'a, K, V, S> {
@@ -57,16 +51,10 @@ impl<'a, K: Eq + Hash, V, S: BuildHasher> Deref for Ref<'a, K, V, S> {
 
 // -- Unique
 
-pub struct RefMut<'a, K: Eq + Hash, V, S: BuildHasher = FxBuildHasher> {
+pub struct RefMut<'a, K, V, S = FxBuildHasher> {
     _guard: RwLockWriteGuard<'a, HashMap<K, V, S>>,
     k: &'a K,
     v: &'a mut V,
-}
-
-unsafe impl<'a, K: Eq + Hash + Send, V: Send, S: BuildHasher> Send for RefMut<'a, K, V, S> {}
-unsafe impl<'a, K: Eq + Hash + Send + Sync, V: Send + Sync, S: BuildHasher> Sync
-    for RefMut<'a, K, V, S>
-{
 }
 
 impl<'a, K: Eq + Hash, V, S: BuildHasher> RefMut<'a, K, V, S> {

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -6,10 +6,7 @@ use serde::Deserializer;
 use std::fmt;
 use std::hash::Hash;
 
-pub struct DashMapVisitor<K, V>
-where
-    K: Eq + Hash,
-{
+pub struct DashMapVisitor<K, V> {
     marker: PhantomData<fn() -> DashMap<K, V>>,
 }
 


### PR DESCRIPTION
Also removed trait bounds from types (they don't actually need to be there)

First: Don't write an implementation of `Send` or `Sync` unless you are writing a synchronization primitive. It is almost never correct (and in this case very wrong!). `parking_lot` doesn't allow rwlocks guards to be sent across threads because unlocking a rwlock guard on a different thread from where it started is UB.

Second: Don't put trait bounds on types, it just makes it harder to compose them for no good reason. It is better to put trait bounds on `impl` blocks, where they will actually be used.