### PR TITLE
WIP: Begin implementing DashSet

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ extern crate qadapt_spin as parking_lot;
 
 pub mod iter;
 pub mod mapref;
+pub mod set;
 mod t;
 mod util;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,7 +205,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
         } else {
             #[allow(dead_code)]
             #[inline]
-            fn shards(&self) -> &[RwLock<HashMap<K, V, S>>] {
+            pub(crate) fn shards(&self) -> &[RwLock<HashMap<K, V, S>>] {
                 &self.shards
             }
         }

--- a/src/set.rs
+++ b/src/set.rs
@@ -192,6 +192,28 @@ impl<'a, T: 'a + Eq + Hash, S: BuildHasher + Clone> DashSet<T, S> {
     {
         self.map.remove(value).is_some()
     }
+
+    /// Retain elements that whose predicates return true
+    /// and discard elements whose predicates return false.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dashmap::set::DashSet;
+    ///
+    /// let ages = DashSet::new();
+    /// ages.insert(15);
+    /// ages.insert(22);
+    /// ages.insert(27);
+    /// ages.retain(|v| *v > 20);
+    /// assert_eq!(ages.len(), 2);
+    /// ```
+    pub fn retain(&self, mut f: impl FnMut(&T) -> bool) {
+        self.map
+            .shards()
+            .iter()
+            .for_each(|s| s.write().retain(|k, _v| f(k)));
+    }
 }
 
 #[cfg(test)]

--- a/src/set.rs
+++ b/src/set.rs
@@ -114,6 +114,84 @@ impl<'a, T: 'a + Eq + Hash, S: BuildHasher + Clone> DashSet<T, S> {
     {
         self.map.contains_key(value)
     }
+
+    /// Returns how many values the set can store without reallocating.
+    pub fn capacity(&self) -> usize {
+        self.map.capacity()
+    }
+
+    /// Fetches the total amount of values stored in the map.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dashmap::set::DashSet;
+    ///
+    /// let people = DashSet::new();
+    /// people.insert("Albin");
+    /// people.insert("Jones");
+    /// people.insert("Charlie");
+    /// assert_eq!(people.len(), 3);
+    /// ```
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    /// Checks if the set is empty or not.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dashmap::set::DashSet;
+    ///
+    /// let s = DashSet::<()>::new();
+    /// assert!(s.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    /// Removes all values in the map.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dashmap::set::DashSet;
+    ///
+    /// let stats = DashSet::new();
+    /// stats.insert("Goals");
+    /// assert!(!stats.is_empty());
+    /// stats.clear();
+    /// assert!(stats.is_empty());
+    /// ```
+    pub fn clear(&self) {
+        self.map.clear()
+    }
+
+    /// Remove excess capacity to reduce memory usage.
+    pub fn shrink_to_fit(&self) {
+        self.map.shrink_to_fit();
+    }
+
+    /// Removes an entry from the set, returning the true if it existed in the set.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dashmap::set::DashSet;
+    ///
+    /// let soccer_team = DashSet::with_capacity(2);
+    /// soccer_team.insert("Jack");
+    /// assert!(soccer_team.remove("Jack"));
+    /// assert!(!soccer_team.remove("Jill"));
+    /// ```
+    pub fn remove<Q: ?Sized>(&self, value: &Q) -> bool
+    where
+        T: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        self.map.remove(value).is_some()
+    }
 }
 
 #[cfg(test)]

--- a/src/set.rs
+++ b/src/set.rs
@@ -23,13 +23,65 @@ impl<'a, T: 'a + Eq + Hash> DashSet<T, RandomState> {
     /// games.insert("Veloren");
     /// ```
     pub fn new() -> Self {
-        Self {
-            map: DashMap::with_hasher(RandomState::default()),
-        }
+        DashSet::with_hasher(RandomState::default())
+    }
+
+    /// Creates a new DashSet with a specified starting capacity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dashmap::set::DashSet;
+    ///
+    /// let ds = DashSet::with_capacity(2);
+    /// ds.insert(2);
+    /// ds.insert(4);
+    /// ```
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        DashSet::with_capacity_and_hasher(capacity, RandomState::default())
     }
 }
 
 impl<'a, T: 'a + Eq + Hash, S: BuildHasher + Clone> DashSet<T, S> {
+    /// Creates a new DashSet with a capacity of 0 and the provided hasher.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dashmap::set::DashSet;
+    /// use std::collections::hash_map::RandomState;
+    ///
+    /// let s = RandomState::new();
+    /// let games = DashSet::with_hasher(s);
+    /// games.insert("Veloren");
+    /// ```
+    pub fn with_hasher(hasher: S) -> Self {
+        Self {
+            map: DashMap::with_hasher(hasher),
+        }
+    }
+
+    /// Creates a new DashSet with a specified starting capacity and hasher.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dashmap::set::DashSet;
+    /// use std::collections::hash_map::RandomState;
+    ///
+    /// let s = RandomState::new();
+    /// let ds = DashSet::with_capacity_and_hasher(2, s);
+    /// ds.insert(2);
+    /// ds.insert(4);
+    /// ```
+    #[inline]
+    pub fn with_capacity_and_hasher(capacity: usize, hasher: S) -> Self {
+        Self {
+            map: DashMap::with_capacity_and_hasher(capacity, hasher),
+        }
+    }
+
     /// Inserts a value into the set.
     ///
     /// # Examples

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,0 +1,77 @@
+//! A concurrent hash set backed by DashMap.
+
+use std::borrow::Borrow;
+use std::collections::hash_map::RandomState;
+use std::hash::{BuildHasher, Hash};
+
+use crate::DashMap;
+
+/// A concurrent hash set backed by DashMap.
+pub struct DashSet<T, S = RandomState> {
+    map: DashMap<T, (), S>,
+}
+
+impl<'a, T: 'a + Eq + Hash> DashSet<T, RandomState> {
+    /// Creates a new DashSet with a capacity of 0.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dashmap::set::DashSet;
+    ///
+    /// let games = DashSet::new();
+    /// games.insert("Veloren");
+    /// ```
+    pub fn new() -> Self {
+        Self {
+            map: DashMap::with_hasher(RandomState::default()),
+        }
+    }
+}
+
+impl<'a, T: 'a + Eq + Hash, S: BuildHasher + Clone> DashSet<T, S> {
+    /// Inserts a value into the set.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dashmap::set::DashSet;
+    ///
+    /// let set = DashSet::new();
+    /// set.insert("I am the value!");
+    /// ```
+    pub fn insert(&self, value: T) -> bool {
+        self.map.insert(value, ()).is_some()
+    }
+
+    /// Checks if the set contains a specific value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dashmap::set::DashSet;
+    ///
+    /// let teams = DashSet::new();
+    /// teams.insert("Dakota Cherries");
+    /// assert!(teams.contains("Dakota Cherries"));
+    /// ```
+    pub fn contains<Q>(&self, value: &Q) -> bool
+    where
+        T: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.map.contains_key(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::set::DashSet;
+
+    #[test]
+    fn test_basic() {
+        let ds = DashSet::new();
+        ds.insert(0);
+        assert!(ds.contains(&0));
+    }
+}


### PR DESCRIPTION
Starting work on #34.

Here are the missing functions from `std::collections::HashMap`:

```
pub fn iter(&self) -> Iter<T>
pub fn get<Q: ?Sized>(&self, value: &Q) -> Option<T>
where
    T: Borrow<Q>,
    Q: Hash + Eq,
pub fn drain(&mut self) -> Drain<T>
pub fn hasher(&self) -> &S
pub fn reserve(&mut self, additional: usize)
pub fn difference<'a>(
    &'a self,
    other: &'a HashSet<T, S>
) -> Difference<'a, T, S>
pub fn symmetric_difference<'a>(
    &'a self,
    other: &'a HashSet<T, S>
) -> SymmetricDifference<'a, T, S>
pub fn intersection<'a>(
    &'a self,
    other: &'a HashSet<T, S>
) -> Intersection<'a, T, S>
pub fn union<'a>(&'a self, other: &'a HashSet<T, S>) -> Union<'a, T, S>
pub fn is_disjoint(&self, other: &HashSet<T, S>) -> bool
pub fn is_subset(&self, other: &HashSet<T, S>) -> bool
pub fn is_superset(&self, other: &HashSet<T, S>) -> bool
pub fn replace(&mut self, value: T) -> Option<T>
pub fn take<Q: ?Sized>(&mut self, value: &Q) -> Option<T> where
    T: Borrow<Q>,
    Q: Hash + Eq,
```

Which includes `iter()` because I wasn't quite sure how to tackle that one, the ones I implemented were pretty straightforward. Some pointing in the right direction would be appreciated!