### PR TITLE
Add DashSet

### DIFF
--- a/src/iter_set.rs
+++ b/src/iter_set.rs
@@ -1,6 +1,6 @@
 use crate::setref::multiple::RefMulti;
 use crate::t::Map;
-use std::hash::{BuildHasher, Hash};
+use core::hash::{BuildHasher, Hash};
 
 pub struct OwningIter<K, S> {
     inner: crate::iter::OwningIter<K, (), S>,

--- a/src/iter_set.rs
+++ b/src/iter_set.rs
@@ -1,9 +1,9 @@
-use std::hash::{BuildHasher, Hash};
-use crate::t::Map;
 use crate::setref::multiple::RefMulti;
+use crate::t::Map;
+use std::hash::{BuildHasher, Hash};
 
 pub struct OwningIter<K, S> {
-    inner: crate::iter::OwningIter<K, (), S>
+    inner: crate::iter::OwningIter<K, (), S>,
 }
 
 impl<K: Eq + Hash, S: BuildHasher + Clone> OwningIter<K, S> {
@@ -36,7 +36,7 @@ where
 }
 
 pub struct Iter<'a, K, S, M> {
-    inner: crate::iter::Iter<'a, K, (), S, M>
+    inner: crate::iter::Iter<'a, K, (), S, M>,
 }
 
 unsafe impl<'a, 'i, K, S, M> Send for Iter<'i, K, S, M>
@@ -61,7 +61,9 @@ impl<'a, K: Eq + Hash, S: 'a + BuildHasher + Clone, M: Map<'a, K, (), S>> Iter<'
     }
 }
 
-impl<'a, K: Eq + Hash, S: 'a + BuildHasher + Clone, M: Map<'a, K, (), S>> Iterator for Iter<'a, K, S, M> {
+impl<'a, K: Eq + Hash, S: 'a + BuildHasher + Clone, M: Map<'a, K, (), S>> Iterator
+    for Iter<'a, K, S, M>
+{
     type Item = RefMulti<'a, K, S>;
 
     #[inline]

--- a/src/iter_set.rs
+++ b/src/iter_set.rs
@@ -1,0 +1,71 @@
+use std::hash::{BuildHasher, Hash};
+use crate::t::Map;
+use crate::setref::multiple::RefMulti;
+
+pub struct OwningIter<K, S> {
+    inner: crate::iter::OwningIter<K, (), S>
+}
+
+impl<K: Eq + Hash, S: BuildHasher + Clone> OwningIter<K, S> {
+    pub(crate) fn new(inner: crate::iter::OwningIter<K, (), S>) -> Self {
+        Self { inner }
+    }
+}
+
+impl<K: Eq + Hash, S: BuildHasher + Clone> Iterator for OwningIter<K, S> {
+    type Item = K;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|(k, _)| k)
+    }
+}
+
+unsafe impl<K, S> Send for OwningIter<K, S>
+where
+    K: Eq + Hash + Send,
+    S: BuildHasher + Clone + Send,
+{
+}
+
+unsafe impl<K, S> Sync for OwningIter<K, S>
+where
+    K: Eq + Hash + Sync,
+    S: BuildHasher + Clone + Sync,
+{
+}
+
+pub struct Iter<'a, K, S, M> {
+    inner: crate::iter::Iter<'a, K, (), S, M>
+}
+
+unsafe impl<'a, 'i, K, S, M> Send for Iter<'i, K, S, M>
+where
+    K: 'a + Eq + Hash + Send,
+    S: 'a + BuildHasher + Clone,
+    M: Map<'a, K, (), S>,
+{
+}
+
+unsafe impl<'a, 'i, K, S, M> Sync for Iter<'i, K, S, M>
+where
+    K: 'a + Eq + Hash + Sync,
+    S: 'a + BuildHasher + Clone,
+    M: Map<'a, K, (), S>,
+{
+}
+
+impl<'a, K: Eq + Hash, S: 'a + BuildHasher + Clone, M: Map<'a, K, (), S>> Iter<'a, K, S, M> {
+    pub(crate) fn new(inner: crate::iter::Iter<'a, K, (), S, M>) -> Self {
+        Self { inner }
+    }
+}
+
+impl<'a, K: Eq + Hash, S: 'a + BuildHasher + Clone, M: Map<'a, K, (), S>> Iterator for Iter<'a, K, S, M> {
+    type Item = RefMulti<'a, K, S>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(RefMulti::new)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::type_complexity)]
 
 pub mod iter;
+pub mod iter_set;
 pub mod lock;
 pub mod mapref;
 mod read_only;
@@ -27,13 +28,13 @@ use mapref::entry::{Entry, OccupiedEntry, VacantEntry};
 use mapref::multiple::RefMulti;
 use mapref::one::{Ref, RefMut};
 pub use read_only::ReadOnlyView;
+pub use set::DashSet;
 use std::borrow::Borrow;
 use std::fmt;
 use std::hash::Hasher;
 use std::hash::{BuildHasher, Hash};
 use std::iter::FromIterator;
 use std::ops::{BitAnd, BitOr, Shl, Shr, Sub};
-pub use set::DashSet;
 pub use t::Map;
 
 cfg_if! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ cfg_if! {
         type HashMap<K, V, S> = std::collections::HashMap<K, SharedValue<V>, S>;
     }
 }
+pub(crate) type HashMap<K, V, S> = std::collections::HashMap<K, SharedValue<V>, S>;
 
 #[inline]
 fn shard_amount() -> usize {
@@ -471,7 +472,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
         self._retain(f);
     }
 
-    /// Fetches the total amount of key-value pairs stored in the map.
+    /// Fetches the total number of key-value pairs stored in the map.
     ///
     /// # Examples
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,8 @@ pub mod iter_set;
 pub mod lock;
 pub mod mapref;
 mod read_only;
-pub mod setref;
-pub mod iter_set;
 mod set;
+pub mod setref;
 mod t;
 mod util;
 
@@ -29,12 +28,6 @@ use mapref::multiple::RefMulti;
 use mapref::one::{Ref, RefMut};
 pub use read_only::ReadOnlyView;
 pub use set::DashSet;
-use std::borrow::Borrow;
-use std::fmt;
-use std::hash::Hasher;
-use std::hash::{BuildHasher, Hash};
-use std::iter::FromIterator;
-use std::ops::{BitAnd, BitOr, Shl, Shr, Sub};
 pub use t::Map;
 
 cfg_if! {
@@ -51,12 +44,11 @@ cfg_if! {
 
         use alloc::{vec::Vec, boxed::Box};
 
-        type HashMap<K, V, S> = hashbrown::HashMap<K, SharedValue<V>, S>;
+        pub(crate) type HashMap<K, V, S> = hashbrown::HashMap<K, SharedValue<V>, S>;
     } else {
-        type HashMap<K, V, S> = std::collections::HashMap<K, SharedValue<V>, S>;
+        pub(crate) type HashMap<K, V, S> = std::collections::HashMap<K, SharedValue<V>, S>;
     }
 }
-pub(crate) type HashMap<K, V, S> = std::collections::HashMap<K, SharedValue<V>, S>;
 
 #[inline]
 fn shard_amount() -> usize {
@@ -257,7 +249,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
             {
                 let hash = self.hash_usize(&key);
 
-                (hash >> self.shift)
+                hash >> self.shift
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,9 @@ pub mod iter;
 pub mod lock;
 pub mod mapref;
 mod read_only;
+pub mod setref;
+pub mod iter_set;
+mod set;
 mod t;
 mod util;
 
@@ -24,6 +27,13 @@ use mapref::entry::{Entry, OccupiedEntry, VacantEntry};
 use mapref::multiple::RefMulti;
 use mapref::one::{Ref, RefMut};
 pub use read_only::ReadOnlyView;
+use std::borrow::Borrow;
+use std::fmt;
+use std::hash::Hasher;
+use std::hash::{BuildHasher, Hash};
+use std::iter::FromIterator;
+use std::ops::{BitAnd, BitOr, Shl, Shr, Sub};
+pub use set::DashSet;
 pub use t::Map;
 
 cfg_if! {
@@ -83,6 +93,7 @@ impl<K: Eq + Hash + Clone, V: Clone, S: Clone> Clone for DashMap<K, V, S> {
             hasher: self.hasher.clone(),
         }
     }
+    // TODO - this should have a custom clone_from
 }
 
 impl<K, V, S> Default for DashMap<K, V, S>

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,10 +1,10 @@
 use crate::DashMap;
+use core::fmt;
+use core::hash::Hash;
 use serde::de::{Deserialize, MapAccess, Visitor};
 use serde::export::PhantomData;
 use serde::ser::{Serialize, SerializeMap, Serializer};
 use serde::Deserializer;
-use std::fmt;
-use std::hash::Hash;
 
 pub struct DashMapVisitor<K, V> {
     marker: PhantomData<fn() -> DashMap<K, V>>,

--- a/src/set.rs
+++ b/src/set.rs
@@ -7,9 +7,9 @@ use crate::DashMap;
 use crate::HashMap;
 use ahash::RandomState;
 use cfg_if::cfg_if;
-use std::borrow::Borrow;
-use std::hash::{BuildHasher, Hash};
-use std::iter::FromIterator;
+use core::borrow::Borrow;
+use core::hash::{BuildHasher, Hash};
+use core::iter::FromIterator;
 
 /// DashSet is a thin wrapper around [`DashMap`] using `()` as the value type. It uses
 /// methods and types which are more convenient to work with on a set.
@@ -110,6 +110,14 @@ impl<'a, K: 'a + Eq + Hash, S: BuildHasher + Clone> DashSet<K, S> {
             inner: DashMap::with_capacity_and_hasher(capacity, hasher),
         }
     }
+
+    /// Hash a given item to produce a usize.
+    /// Uses the provided or default HashBuilder.
+    #[inline]
+    pub fn hash_usize<T: Hash>(&self, item: &T) -> usize {
+        self.inner.hash_usize(item)
+    }
+
     cfg_if! {
         if #[cfg(feature = "raw-api")] {
             /// Allows you to peek at the inner shards that store your data.
@@ -169,7 +177,7 @@ impl<'a, K: 'a + Eq + Hash, S: BuildHasher + Clone> DashSet<K, S> {
             /// ```
             /// use dashmap::DashSet;
             ///
-            /// let set = DashSet::new();
+            /// let set: DashSet<i32> = DashSet::new();
             /// let key = "key";
             /// let hash = set.hash_usize(&key);
             /// println!("hash is stored in shard: {}", set.determine_shard(hash));

--- a/src/set.rs
+++ b/src/set.rs
@@ -3,17 +3,19 @@ use std::borrow::Borrow;
 use std::hash::{BuildHasher, Hash};
 use std::iter::FromIterator;
 
-use crate::DashMap;
-use crate::setref::one::Ref;
 use crate::iter_set::{Iter, OwningIter};
+use crate::setref::one::Ref;
+use crate::DashMap;
 
 pub struct DashSet<K, S = RandomState> {
-    inner: DashMap<K, (), S>
+    inner: DashMap<K, (), S>,
 }
 
 impl<K: Eq + Hash + Clone, S: Clone> Clone for DashSet<K, S> {
     fn clone(&self) -> Self {
-        Self { inner: self.inner.clone() }
+        Self {
+            inner: self.inner.clone(),
+        }
     }
 
     fn clone_from(&mut self, source: &Self) {
@@ -51,7 +53,9 @@ impl<'a, K: 'a + Eq + Hash, S: BuildHasher + Clone> DashSet<K, S> {
     }
     #[inline]
     pub fn with_capacity_and_hasher(capacity: usize, hasher: S) -> Self {
-        Self { inner: DashMap::with_capacity_and_hasher(capacity, hasher) }
+        Self {
+            inner: DashMap::with_capacity_and_hasher(capacity, hasher),
+        }
     }
     // TODO: Self::shards()
     // TODO: Self::determine_map(key)
@@ -131,7 +135,7 @@ impl<'a, K: 'a + Eq + Hash, S: BuildHasher + Clone> DashSet<K, S> {
     pub fn contains<Q>(&self, key: &Q) -> bool
     where
         K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized
+        Q: Hash + Eq + ?Sized,
     {
         self.inner.contains_key(key)
     }

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,0 +1,198 @@
+use ahash::RandomState;
+use std::borrow::Borrow;
+use std::hash::{BuildHasher, Hash};
+use std::iter::FromIterator;
+
+use crate::DashMap;
+use crate::setref::one::Ref;
+use crate::iter_set::{Iter, OwningIter};
+
+pub struct DashSet<K, S = RandomState> {
+    inner: DashMap<K, (), S>
+}
+
+impl<K: Eq + Hash + Clone, S: Clone> Clone for DashSet<K, S> {
+    fn clone(&self) -> Self {
+        Self { inner: self.inner.clone() }
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.inner.clone_from(&source.inner)
+    }
+}
+
+impl<K, S> Default for DashSet<K, S>
+where
+    K: Eq + Hash,
+    S: Default + BuildHasher + Clone,
+{
+    #[inline]
+    fn default() -> Self {
+        Self::with_hasher(Default::default())
+    }
+}
+
+impl<'a, K: 'a + Eq + Hash> DashSet<K, RandomState> {
+    #[inline]
+    pub fn new() -> Self {
+        Self::with_hasher(RandomState::default())
+    }
+
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self::with_capacity_and_hasher(capacity, RandomState::default())
+    }
+}
+
+impl<'a, K: 'a + Eq + Hash, S: BuildHasher + Clone> DashSet<K, S> {
+    #[inline]
+    pub fn with_hasher(hasher: S) -> Self {
+        Self::with_capacity_and_hasher(0, hasher)
+    }
+    #[inline]
+    pub fn with_capacity_and_hasher(capacity: usize, hasher: S) -> Self {
+        Self { inner: DashMap::with_capacity_and_hasher(capacity, hasher) }
+    }
+    // TODO: Self::shards()
+    // TODO: Self::determine_map(key)
+    // TODO: Self::determine_shard(hash)
+
+    #[inline]
+    pub fn insert(&self, key: K) -> bool {
+        self.inner.insert(key, ()).is_none()
+    }
+
+    #[inline]
+    pub fn remove<Q>(&self, key: &Q) -> Option<K>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.inner.remove(key).map(|(k, _)| k)
+    }
+
+    #[inline]
+    pub fn remove_if<Q>(&self, key: &Q, f: impl FnOnce(&K) -> bool) -> Option<K>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        // TODO: Don't create another closure around f
+        self.inner.remove_if(key, |k, _| f(k)).map(|(k, _)| k)
+    }
+
+    #[inline]
+    pub fn iter(&'a self) -> Iter<'a, K, S, DashMap<K, (), S>> {
+        let iter = self.inner.iter();
+        Iter::new(iter)
+    }
+
+    #[inline]
+    pub fn get<Q>(&'a self, key: &Q) -> Option<Ref<'a, K, S>>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.inner.get(key).map(Ref::new)
+    }
+
+    #[inline]
+    pub fn shrink_to_fit(&self) {
+        self.inner.shrink_to_fit()
+    }
+
+    #[inline]
+    pub fn retain(&self, mut f: impl FnMut(&K) -> bool) {
+        // TODO: Don't create another closure
+        self.inner.retain(|k, _| f(k))
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    #[inline]
+    pub fn clear(&self) {
+        self.inner.clear()
+    }
+
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.inner.capacity()
+    }
+
+    #[inline]
+    pub fn contains<Q>(&self, key: &Q) -> bool
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized
+    {
+        self.inner.contains_key(key)
+    }
+}
+
+impl<'a, K: Eq + Hash, S: BuildHasher + Clone> IntoIterator for DashSet<K, S> {
+    type Item = K;
+    type IntoIter = OwningIter<K, S>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        OwningIter::new(self.inner.into_iter())
+    }
+}
+
+impl<K: Eq + Hash, S: BuildHasher + Clone> Extend<K> for DashSet<K, S> {
+    fn extend<T: IntoIterator<Item = K>>(&mut self, iter: T) {
+        let iter = iter.into_iter().map(|k| (k, ()));
+        self.inner.extend(iter)
+    }
+}
+
+impl<K: Eq + Hash> FromIterator<K> for DashSet<K, RandomState> {
+    fn from_iter<I: IntoIterator<Item = K>>(iter: I) -> Self {
+        let mut set = DashSet::new();
+        set.extend(iter);
+        set
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::DashSet;
+
+    #[test]
+    fn test_basic() {
+        let set = DashSet::new();
+        set.insert(0);
+        assert_eq!(set.get(&0).as_deref(), Some(&0));
+    }
+
+    #[test]
+    fn test_default() {
+        let set: DashSet<u32> = DashSet::default();
+        set.insert(0);
+        assert_eq!(set.get(&0).as_deref(), Some(&0));
+    }
+
+    #[test]
+    fn test_multiple_hashes() {
+        let set = DashSet::<u32>::default();
+        for i in 0..100 {
+            assert!(set.insert(i));
+        }
+        for i in 0..100 {
+            assert!(!set.insert(i));
+        }
+        for i in 0..100 {
+            assert_eq!(Some(i), set.remove(&i));
+        }
+        for i in 0..100 {
+            assert_eq!(None, set.remove(&i));
+        }
+    }
+}

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,12 +1,20 @@
+use crate::iter_set::{Iter, OwningIter};
+#[cfg(feature = "raw-api")]
+use crate::lock::RwLock;
+use crate::setref::one::Ref;
+use crate::DashMap;
+#[cfg(feature = "raw-api")]
+use crate::HashMap;
 use ahash::RandomState;
+use cfg_if::cfg_if;
 use std::borrow::Borrow;
 use std::hash::{BuildHasher, Hash};
 use std::iter::FromIterator;
 
-use crate::iter_set::{Iter, OwningIter};
-use crate::setref::one::Ref;
-use crate::DashMap;
-
+/// DashSet is a thin wrapper around [`DashMap`] using `()` as the value type. It uses
+/// methods and types which are more convenient to work with on a set.
+///
+/// [`DashMap`]: struct.DashMap.html
 pub struct DashSet<K, S = RandomState> {
     inner: DashMap<K, (), S>,
 }
@@ -35,11 +43,31 @@ where
 }
 
 impl<'a, K: 'a + Eq + Hash> DashSet<K, RandomState> {
+    /// Creates a new DashSet with a capacity of 0.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dashmap::DashSet;
+    ///
+    /// let games = DashSet::new();
+    /// games.insert("Veloren");
+    /// ```
     #[inline]
     pub fn new() -> Self {
         Self::with_hasher(RandomState::default())
     }
-
+    /// Creates a new DashMap with a specified starting capacity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dashmap::DashSet;
+    ///
+    /// let numbers = DashSet::with_capacity(2);
+    /// numbers.insert(2);
+    /// numbers.insert(8);
+    /// ```
     #[inline]
     pub fn with_capacity(capacity: usize) -> Self {
         Self::with_capacity_and_hasher(capacity, RandomState::default())
@@ -47,25 +75,136 @@ impl<'a, K: 'a + Eq + Hash> DashSet<K, RandomState> {
 }
 
 impl<'a, K: 'a + Eq + Hash, S: BuildHasher + Clone> DashSet<K, S> {
+    /// Creates a new DashMap with a capacity of 0 and the provided hasher.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dashmap::DashSet;
+    /// use std::collections::hash_map::RandomState;
+    ///
+    /// let s = RandomState::new();
+    /// let games = DashSet::with_hasher(s);
+    /// games.insert("Veloren");
+    /// ```
     #[inline]
     pub fn with_hasher(hasher: S) -> Self {
         Self::with_capacity_and_hasher(0, hasher)
     }
+    /// Creates a new DashMap with a specified starting capacity and hasher.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dashmap::DashSet;
+    /// use std::collections::hash_map::RandomState;
+    ///
+    /// let s = RandomState::new();
+    /// let numbers = DashSet::with_capacity_and_hasher(2, s);
+    /// numbers.insert(2);
+    /// numbers.insert(8);
+    /// ```
     #[inline]
     pub fn with_capacity_and_hasher(capacity: usize, hasher: S) -> Self {
         Self {
             inner: DashMap::with_capacity_and_hasher(capacity, hasher),
         }
     }
-    // TODO: Self::shards()
-    // TODO: Self::determine_map(key)
-    // TODO: Self::determine_shard(hash)
-
+    cfg_if! {
+        if #[cfg(feature = "raw-api")] {
+            /// Allows you to peek at the inner shards that store your data.
+            /// You should probably not use this unless you know what you are doing.
+            ///
+            /// Requires the `raw-api` feature to be enabled.
+            ///
+            /// # Examples
+            ///
+            /// ```
+            /// use dashmap::DashSet;
+            ///
+            /// let set = DashSet::<()>::new();
+            /// println!("Amount of shards: {}", set.shards().len());
+            /// ```
+            #[inline]
+            pub fn shards(&self) -> &[RwLock<HashMap<K, (), S>>] {
+                self.inner.shards()
+            }
+        }
+    }
+    cfg_if! {
+        if #[cfg(feature = "raw-api")] {
+            /// Finds which shard a certain key is stored in.
+            /// You should probably not use this unless you know what you are doing.
+            /// Note that shard selection is dependent on the default or provided HashBuilder.
+            ///
+            /// Requires the `raw-api` feature to be enabled.
+            ///
+            /// # Examples
+            ///
+            /// ```
+            /// use dashmap::DashSet;
+            ///
+            /// let set = DashSet::new();
+            /// set.insert("coca-cola");
+            /// println!("coca-cola is stored in shard: {}", set.determine_map("coca-cola"));
+            /// ```
+            #[inline]
+            pub fn determine_map<Q>(&self, key: &Q) -> usize
+            where
+                K: Borrow<Q>,
+                Q: Hash + Eq + ?Sized,
+            {
+                self.inner.determine_map(key)
+            }
+        }
+    }
+    cfg_if! {
+        if #[cfg(feature = "raw-api")] {
+            /// Finds which shard a certain hash is stored in.
+            ///
+            /// Requires the `raw-api` feature to be enabled.
+            ///
+            /// # Examples
+            ///
+            /// ```
+            /// use dashmap::DashSet;
+            ///
+            /// let set = DashSet::new();
+            /// let key = "key";
+            /// let hash = set.hash_usize(&key);
+            /// println!("hash is stored in shard: {}", set.determine_shard(hash));
+            /// ```
+            #[inline]
+            pub fn determine_shard(&self, hash: usize) -> usize {
+                self.inner.determine_shard(hash)
+            }
+        }
+    }
+    /// Inserts a key into the set. Returns true if the key was not already in the set.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dashmap::DashSet;
+    ///
+    /// let set = DashSet::new();
+    /// set.insert("I am the key!");
+    /// ```
     #[inline]
     pub fn insert(&self, key: K) -> bool {
         self.inner.insert(key, ()).is_none()
     }
-
+    /// Removes an entry from the map, returning the key if it existed in the map.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dashmap::DashSet;
+    ///
+    /// let soccer_team = DashSet::new();
+    /// soccer_team.insert("Jack");
+    /// assert_eq!(soccer_team.remove("Jack").unwrap(), "Jack");
+    /// ```
     #[inline]
     pub fn remove<Q>(&self, key: &Q) -> Option<K>
     where
@@ -74,7 +213,25 @@ impl<'a, K: 'a + Eq + Hash, S: BuildHasher + Clone> DashSet<K, S> {
     {
         self.inner.remove(key).map(|(k, _)| k)
     }
-
+    /// Removes an entry from the set, returning the key
+    /// if the entry existed and the provided conditional function returned true.
+    ///
+    /// ```
+    /// use dashmap::DashSet;
+    ///
+    /// let soccer_team = DashSet::new();
+    /// soccer_team.insert("Sam");
+    /// soccer_team.remove_if("Sam", |player| player.starts_with("Ja"));
+    /// assert!(soccer_team.contains("Sam"));
+    /// ```
+    /// ```
+    /// use dashmap::DashSet;
+    ///
+    /// let soccer_team = DashSet::new();
+    /// soccer_team.insert("Sam");
+    /// soccer_team.remove_if("Jacob", |player| player.starts_with("Ja"));
+    /// assert!(!soccer_team.contains("Jacob"));
+    /// ```
     #[inline]
     pub fn remove_if<Q>(&self, key: &Q, f: impl FnOnce(&K) -> bool) -> Option<K>
     where
@@ -84,13 +241,33 @@ impl<'a, K: 'a + Eq + Hash, S: BuildHasher + Clone> DashSet<K, S> {
         // TODO: Don't create another closure around f
         self.inner.remove_if(key, |k, _| f(k)).map(|(k, _)| k)
     }
-
+    /// Creates an iterator over a DashMap yielding immutable references.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dashmap::DashSet;
+    ///
+    /// let words = DashSet::new();
+    /// words.insert("hello");
+    /// assert_eq!(words.iter().count(), 1);
+    /// ```
     #[inline]
     pub fn iter(&'a self) -> Iter<'a, K, S, DashMap<K, (), S>> {
         let iter = self.inner.iter();
         Iter::new(iter)
     }
-
+    /// Get a reference to an entry in the set
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dashmap::DashSet;
+    ///
+    /// let youtubers = DashSet::new();
+    /// youtubers.insert("Bosnian Bill");
+    /// assert_eq!(*youtubers.get("Bosnian Bill").unwrap(), "Bosnian Bill");
+    /// ```
     #[inline]
     pub fn get<Q>(&'a self, key: &Q) -> Option<Ref<'a, K, S>>
     where
@@ -99,38 +276,95 @@ impl<'a, K: 'a + Eq + Hash, S: BuildHasher + Clone> DashSet<K, S> {
     {
         self.inner.get(key).map(Ref::new)
     }
-
+    /// Remove excess capacity to reduce memory usage.
     #[inline]
     pub fn shrink_to_fit(&self) {
         self.inner.shrink_to_fit()
     }
-
+    /// Retain elements that whose predicates return true
+    /// and discard elements whose predicates return false.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dashmap::DashSet;
+    ///
+    /// let people = DashSet::new();
+    /// people.insert("Albin");
+    /// people.insert("Jones");
+    /// people.insert("Charlie");
+    /// people.retain(|name| name.contains('i'));
+    /// assert_eq!(people.len(), 2);
+    /// ```
     #[inline]
     pub fn retain(&self, mut f: impl FnMut(&K) -> bool) {
         // TODO: Don't create another closure
         self.inner.retain(|k, _| f(k))
     }
-
+    /// Fetches the total number of keys stored in the set.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dashmap::DashSet;
+    ///
+    /// let people = DashSet::new();
+    /// people.insert("Albin");
+    /// people.insert("Jones");
+    /// people.insert("Charlie");
+    /// assert_eq!(people.len(), 3);
+    /// ```
     #[inline]
     pub fn len(&self) -> usize {
         self.inner.len()
     }
-
+    /// Checks if the set is empty or not.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dashmap::DashSet;
+    ///
+    /// let map = DashSet::<()>::new();
+    /// assert!(map.is_empty());
+    /// ```
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
-
+    /// Removes all keys in the set.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dashmap::DashSet;
+    ///
+    /// let people = DashSet::new();
+    /// people.insert("Albin");
+    /// assert!(!people.is_empty());
+    /// people.clear();
+    /// assert!(people.is_empty());
+    /// ```
     #[inline]
     pub fn clear(&self) {
         self.inner.clear()
     }
-
+    /// Returns how many keys the set can store without reallocating.
     #[inline]
     pub fn capacity(&self) -> usize {
         self.inner.capacity()
     }
-
+    /// Checks if the set contains a specific key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dashmap::DashSet;
+    ///
+    /// let people = DashSet::new();
+    /// people.insert("Dakota Cherries");
+    /// assert!(people.contains("Dakota Cherries"));
+    /// ```
     #[inline]
     pub fn contains<Q>(&self, key: &Q) -> bool
     where

--- a/src/setref/mod.rs
+++ b/src/setref/mod.rs
@@ -1,0 +1,2 @@
+pub mod one;
+pub mod multiple;

--- a/src/setref/mod.rs
+++ b/src/setref/mod.rs
@@ -1,2 +1,2 @@
-pub mod one;
 pub mod multiple;
+pub mod one;

--- a/src/setref/multiple.rs
+++ b/src/setref/multiple.rs
@@ -1,0 +1,29 @@
+use ahash::RandomState;
+use std::hash::BuildHasher;
+use std::hash::Hash;
+use std::ops::Deref;
+
+use crate::mapref;
+
+pub struct RefMulti<'a, K, S = RandomState> {
+    inner: mapref::multiple::RefMulti<'a, K, (), S>
+}
+
+impl<'a, K: Eq + Hash, S: BuildHasher> RefMulti<'a, K, S> {
+    #[inline(always)]
+    pub(crate) fn new(inner: mapref::multiple::RefMulti<'a, K, (), S>) -> Self {
+        Self { inner }
+    }
+    #[inline(always)]
+    pub fn key(&self) -> &K {
+        self.inner.key()
+    }
+}
+
+impl<'a, K: Eq + Hash, S: BuildHasher> Deref for RefMulti<'a, K, S> {
+    type Target = K;
+    #[inline(always)]
+    fn deref(&self) -> &K {
+        self.key()
+    }
+}

--- a/src/setref/multiple.rs
+++ b/src/setref/multiple.rs
@@ -6,7 +6,7 @@ use std::ops::Deref;
 use crate::mapref;
 
 pub struct RefMulti<'a, K, S = RandomState> {
-    inner: mapref::multiple::RefMulti<'a, K, (), S>
+    inner: mapref::multiple::RefMulti<'a, K, (), S>,
 }
 
 impl<'a, K: Eq + Hash, S: BuildHasher> RefMulti<'a, K, S> {

--- a/src/setref/multiple.rs
+++ b/src/setref/multiple.rs
@@ -1,7 +1,6 @@
 use ahash::RandomState;
-use std::hash::BuildHasher;
-use std::hash::Hash;
-use std::ops::Deref;
+use core::hash::{BuildHasher, Hash};
+use core::ops::Deref;
 
 use crate::mapref;
 

--- a/src/setref/one.rs
+++ b/src/setref/one.rs
@@ -1,0 +1,57 @@
+use crate::mapref;
+use ahash::RandomState;
+use std::hash::{BuildHasher, Hash};
+use std::ops::Deref;
+
+pub struct Ref<'a, K, S = RandomState> {
+    inner: mapref::one::Ref<'a, K, (), S>
+}
+
+unsafe impl<'a, K: Eq + Hash + Send, S: BuildHasher> Send for Ref<'a, K, S> {}
+unsafe impl<'a, K: Eq + Hash + Send + Sync, S: BuildHasher> Sync
+    for Ref<'a, K, S>
+{
+}
+
+impl<'a, K: Eq + Hash, S: BuildHasher> Ref<'a, K, S> {
+    #[inline(always)]
+    pub(crate) fn new(inner: mapref::one::Ref<'a, K, (), S>) -> Self {
+        Self { inner }
+    }
+    #[inline(always)]
+    pub fn key(&self) -> &K {
+        self.inner.key()
+    }
+}
+
+impl<'a, K: Eq + Hash, S: BuildHasher> Deref for Ref<'a, K, S> {
+    type Target = K;
+    #[inline(always)]
+    fn deref(&self) -> &K {
+        self.key()
+    }
+}
+
+
+// No need for RefMut - cannot mutate key in hashmap anyway
+// pub struct RefMut<'a, K, S = RandomState> {
+//     inner: mapref::one::RefMut<'a, K, (), S>
+// }
+
+// unsafe impl<'a, K: Eq + Hash + Send, S: BuildHasher> Send for RefMut<'a, K, S> {}
+// unsafe impl<'a, K: Eq + Hash + Send + Sync, S: BuildHasher> Sync
+//     for RefMut<'a, K, S>
+// {
+// }
+
+// impl<'a, K: Eq + Hash, S: BuildHasher> Ref<'a, K, S> {
+//     #[inline(always)]
+//     pub(crate) fn new(inner: mapref::one::RefMut<'a, K, (), S>) -> Self {
+//         Self { inner }
+//     }
+//     #[inline(always)]
+//     pub fn key(&self) -> &K {
+//         self.inner.key()
+//     }
+// }
+

--- a/src/setref/one.rs
+++ b/src/setref/one.rs
@@ -4,14 +4,11 @@ use std::hash::{BuildHasher, Hash};
 use std::ops::Deref;
 
 pub struct Ref<'a, K, S = RandomState> {
-    inner: mapref::one::Ref<'a, K, (), S>
+    inner: mapref::one::Ref<'a, K, (), S>,
 }
 
 unsafe impl<'a, K: Eq + Hash + Send, S: BuildHasher> Send for Ref<'a, K, S> {}
-unsafe impl<'a, K: Eq + Hash + Send + Sync, S: BuildHasher> Sync
-    for Ref<'a, K, S>
-{
-}
+unsafe impl<'a, K: Eq + Hash + Send + Sync, S: BuildHasher> Sync for Ref<'a, K, S> {}
 
 impl<'a, K: Eq + Hash, S: BuildHasher> Ref<'a, K, S> {
     #[inline(always)]

--- a/src/setref/one.rs
+++ b/src/setref/one.rs
@@ -1,7 +1,7 @@
 use crate::mapref;
 use ahash::RandomState;
-use std::hash::{BuildHasher, Hash};
-use std::ops::Deref;
+use core::hash::{BuildHasher, Hash};
+use core::ops::Deref;
 
 pub struct Ref<'a, K, S = RandomState> {
     inner: mapref::one::Ref<'a, K, (), S>,

--- a/src/setref/one.rs
+++ b/src/setref/one.rs
@@ -31,27 +31,3 @@ impl<'a, K: Eq + Hash, S: BuildHasher> Deref for Ref<'a, K, S> {
         self.key()
     }
 }
-
-
-// No need for RefMut - cannot mutate key in hashmap anyway
-// pub struct RefMut<'a, K, S = RandomState> {
-//     inner: mapref::one::RefMut<'a, K, (), S>
-// }
-
-// unsafe impl<'a, K: Eq + Hash + Send, S: BuildHasher> Send for RefMut<'a, K, S> {}
-// unsafe impl<'a, K: Eq + Hash + Send + Sync, S: BuildHasher> Sync
-//     for RefMut<'a, K, S>
-// {
-// }
-
-// impl<'a, K: Eq + Hash, S: BuildHasher> Ref<'a, K, S> {
-//     #[inline(always)]
-//     pub(crate) fn new(inner: mapref::one::RefMut<'a, K, (), S>) -> Self {
-//         Self { inner }
-//     }
-//     #[inline(always)]
-//     pub fn key(&self) -> &K {
-//         self.inner.key()
-//     }
-// }
-


### PR DESCRIPTION
This is not yet complete, but should have all functionality working. Mostly it is just documentation that is missing.

Would close #34

I figure you can review what is here until I work on docs (will probably get to it in the next few days).

The Std HashSet implements `remove` as returning a bool and has a separate `take` that returns the item. I implemented `remove` so that it returns the item as I felt this was similar to DashMap's remove (which differs from std by returning `(K, V)` instead of just `V`). I can change this if you think it should be the same API as std.

Also, I'm not sure if things should be moved around. I tried to basically mirror the way DashMap is organized by creating a `mod setref` and `mod iter_set` though I could move things around if needed (I think it might be better to put this all in one module).

PS: I added a note about implementing `clone_from` on DashMap (and implemented `clone_from` on DashSet so that when this happens DashSet is already using it) however I don't intend on implementing it in this PR. I might try implementing it in a later PR. I'll open an issue so it isn't forgotten.