### PR TITLE
Added no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ keywords = ["atomic", "concurrent", "hashmap"]
 categories = ["concurrency", "algorithms", "data-structures"]
 
 [features]
+default = []
 raw-api = []
+no_std = ["hashbrown"]
 
 [dev-dependencies]
 criterion = "0.3.0"
@@ -44,6 +46,7 @@ num_cpus = "1.11.1"
 ahash = "0.3.1"
 serde = { version = "1.0.104", optional = true, features = ["derive"] }
 cfg-if = "0.1.10"
+hashbrown = { version = "0.7.1", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -4,10 +4,18 @@ use crate::lock::{RwLockReadGuard, RwLockWriteGuard};
 use crate::t::Map;
 use crate::util::SharedValue;
 use crate::{DashMap, HashMap};
-use std::collections::hash_map;
-use std::hash::{BuildHasher, Hash};
-use std::mem;
-use std::sync::Arc;
+use core::hash::{BuildHasher, Hash};
+use core::mem;
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "no_std")] {
+        use alloc::sync::Arc;
+        use hashbrown::hash_map;
+    } else {
+        use std::sync::Arc;
+        use std::collections::hash_map;
+    }
+}
 
 /// Iterator over a DashMap yielding key value pairs.
 ///

--- a/src/mapref/entry.rs
+++ b/src/mapref/entry.rs
@@ -4,9 +4,9 @@ use crate::util;
 use crate::util::SharedValue;
 use crate::HashMap;
 use ahash::RandomState;
-use std::hash::{BuildHasher, Hash};
-use std::mem;
-use std::ptr;
+use core::hash::{BuildHasher, Hash};
+use core::mem;
+use core::ptr;
 
 pub enum Entry<'a, K, V, S = RandomState> {
     Occupied(OccupiedEntry<'a, K, V, S>),

--- a/src/mapref/multiple.rs
+++ b/src/mapref/multiple.rs
@@ -1,10 +1,17 @@
 use crate::lock::{RwLockReadGuard, RwLockWriteGuard};
 use crate::HashMap;
 use ahash::RandomState;
-use std::hash::BuildHasher;
-use std::hash::Hash;
-use std::ops::{Deref, DerefMut};
-use std::sync::Arc;
+use core::hash::BuildHasher;
+use core::hash::Hash;
+use core::ops::{Deref, DerefMut};
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "no_std")] {
+        use alloc::sync::Arc;
+    } else {
+        use std::sync::Arc;
+    }
+}
 
 // -- Shared
 

--- a/src/mapref/one.rs
+++ b/src/mapref/one.rs
@@ -1,8 +1,8 @@
 use crate::lock::{RwLockReadGuard, RwLockWriteGuard};
 use crate::HashMap;
 use ahash::RandomState;
-use std::hash::{BuildHasher, Hash};
-use std::ops::{Deref, DerefMut};
+use core::hash::{BuildHasher, Hash};
+use core::ops::{Deref, DerefMut};
 
 // -- Shared
 

--- a/src/t.rs
+++ b/src/t.rs
@@ -5,8 +5,8 @@ use crate::lock::{RwLockReadGuard, RwLockWriteGuard};
 use crate::mapref::entry::Entry;
 use crate::mapref::one::{Ref, RefMut};
 use crate::HashMap;
-use std::borrow::Borrow;
-use std::hash::{BuildHasher, Hash};
+use core::borrow::Borrow;
+use core::hash::{BuildHasher, Hash};
 
 /// Implementation detail that is exposed due to generic constraints in public types.
 pub trait Map<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + Clone + BuildHasher> {


### PR DESCRIPTION
Basically the only changes were changing imports from `std` to `core` and adding the dependency `hashbrown` for the `no_std` feature. `hashbrown` is used only to replace std's `HashMap`, everything else is the same code, and should in reality deviate even less from std than it would seem, as std itself depends on hashbrown for the things we depend on (`std::collections::hash_map` is a thin wrapper over `hashbrown::hash_map`, which this PR imports directly)
Adding no_std support was a breeze, apart from one hitch, `AbortOnPanic`. I left a comment there, but I'll just paste it here for convenience:

This is hard, as core/no_std has no concept of threads or knowledge of panicking.
An alternative would be to do this:

```rust
// Elsewhere in the library/host binary
use core::sync::atomic::{AtomicBool, Ordering};

static UNWINDING: AtomicBool = AtomicBool::new(false);

#[panic_handler]
fn panic(info: &PanicInfo) -> ! {
     UNWINDING.store(true, Ordering::Relaxed);

     unsafe {
         core::intrinsics::abort();
     }
}

// In AbortOnPanic::drop
if UNWINDING.load(Ordering::Relaxed) {
     unsafe {
         core::intrinsics::abort();
     }
}
```

Now, this isn't an ideal solution for multiple reasons, as it uses intrinsics which require a feature
and can be overwritten by the user without them even knowing. That being said, *most* users of no_std
do tend to use `panic = "abort"`, which solves this problem for us by aborting on panics.