### PR TITLE
Added the `DashMap::hasher` method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,6 +270,25 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
         }
     }
 
+    /// Returns a reference to the map's [`BuildHasher`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use dashmap::DashMap;
+    /// use ahash::RandomState;
+    ///
+    /// let hasher = RandomState::new();
+    /// let map: DashMap<i32, i32> = DashMap::new();
+    /// let hasher: &RandomState = map.hasher();
+    /// ```
+    ///
+    /// [`BuildHasher`]: https://doc.rust-lang.org/std/hash/trait.BuildHasher.html
+    #[inline]
+    pub fn hasher(&self) -> &S {
+        &self.hasher
+    }
+
     /// Inserts a key and a value into the map.
     ///
     /// # Examples


### PR DESCRIPTION
Added the `DashMap::hasher` method to allow users to obtain a reference to the internal hasher of the current map, giving more parity with std's `HashMap`. Based off of the [`HashMap::hasher`] method

[`HashMap::hasher`]: https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.hasher