### PR TITLE
Add into_key() to Entry (was only on VacantEntry)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dashmap"
-version = "3.11.4"
+version = "3.11.7"
 authors = ["Acrimon <joel.wejdenstal@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -804,7 +804,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
             unsafe {
                 let kptr = util::change_lifetime_const(kptr);
                 let vptr = &mut *vptr.as_ptr();
-                Entry::Occupied(OccupiedEntry::new(shard, Some(key), (kptr, vptr)))
+                Entry::Occupied(OccupiedEntry::new(shard, key, (kptr, vptr)))
             }
         } else {
             Entry::Vacant(VacantEntry::new(shard, key))


### PR DESCRIPTION
Before this change one needed to clone() key before uses of entry
api that might return OccupiedEntry. Now you can do .into_key() and
use the key again for something else.

The enabler for this was that OccupiedEntry's key was an Option<K>,
but was always used as Some(). Fixing this to be K made into_key()
pretty simple to add.

Tested with cargo test