### PR TITLE
Re-export ahash::RandomState

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ mod util;
 #[cfg(feature = "serde")]
 mod serde;
 
-use ahash::RandomState;
+pub use ahash::RandomState;
 use cfg_if::cfg_if;
 use core::borrow::Borrow;
 use core::fmt;


### PR DESCRIPTION
While writing the method `Server::connections()` for the [webwire](https://webwire.dev/) project which returns an iterator of `Connections` I had to use the `ahash` crate in order to wrap an `dashmap::iter::Iter` in my own struct: https://github.com/webwire/webwire-rust/blob/master/src/server/mod.rs#L73

Latest `ahash` crate version is `0.4.4` and DashMap still uses `0.3.*` so it would be nice if I would not need to depend on `ahash=0.3` directly but rather use `dashmap::RandomState` instead which re-exports `ahash::RandomState`.

If there maybe a better way to wrap the iterator of DashMap?