### PR TITLE
Cargo: bump ahash to ^0.4.4 and hashbrown to ^0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ no_std = ["hashbrown"]
 
 [dependencies]
 num_cpus = "1.13.0"
-ahash = "0.3.8"
+ahash = "0.4.4"
 serde = { version = "1.0.114", optional = true, features = ["derive"] }
 cfg-if = "0.1.10"
-hashbrown = { version = "0.8.0", optional = true }
+hashbrown = { version = "0.9.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["raw-api", "serde"]


### PR DESCRIPTION
The bump to ahash 0.4.4 matches the dependency in hashbrown 0.9.0 and 0.9.1.

No code changes seem to be necessary for these updates.
Both `cargo test` and `cargo test --all-features` were successful on my system.