### PR TITLE
Disable ahash's compile-time-rng feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ no_std = ["hashbrown"]
 
 [dependencies]
 num_cpus = "1.13.0"
-ahash = "0.3.8"
+ahash = { version = "0.3.8", default-features = false }
 serde = { version = "1.0.114", optional = true, features = ["derive"] }
 cfg-if = "0.1.10"
 hashbrown = { version = "0.8.0", optional = true }


### PR DESCRIPTION
compile-time-rng feature harms reproducibility due to random number generation at runtime. Fixes #106 as much as possible for 0.3 without breaking backwards compatibility.