### PR TITLE
RFC: ContentsView Type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["concurrency", "algorithms", "data-structures"]
 
 [features]
 default = []
+contents-view = [ "stable_borrow" ]
 raw-api = []
 
 [dependencies]
@@ -21,6 +22,7 @@ num_cpus = "1.13.0"
 serde = { version = "1.0.118", optional = true, features = ["derive"] }
 cfg-if = "1.0.0"
 rayon = { version = "1.5.0", optional = true }
+stable_borrow = { version = "1.0", optional = true }
 
 [package.metadata.docs.rs]
-features = ["rayon", "raw-api", "serde"]
+features = ["contents-view", "rayon", "raw-api", "serde"]

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ If you have any suggestions or tips do not hesitate to open an issue or a PR.
 [![minimum rustc version](https://img.shields.io/badge/rustc-1.44.1-orange.svg)](https://crates.io/crates/dashmap)
 
 ## Cargo features
+- `contents-view` - Enables the `ContentsView` type, which provides raw access to the contents of
+   the map while allowing append-only mutation.
 
 - `serde` - Enables serde support.
 

--- a/src/contents_view.rs
+++ b/src/contents_view.rs
@@ -1,0 +1,253 @@
+use crate::mapref::entry::Entry;
+use crate::DashMap;
+
+use core::borrow::Borrow;
+use core::fmt;
+use core::hash::{BuildHasher, Hash};
+use std::collections::hash_map::RandomState;
+
+use stable_borrow::StableBorrow;
+
+/// An intrusive view into a [`DashMap`]. Allows obtaining raw references to
+/// the contents of stored values while maintaining the ability to add items to
+/// the map.
+pub struct ContentsView<K, V, S = RandomState> {
+    map: DashMap<K, V, S>,
+}
+
+impl<K: Eq + Hash + Clone, V: Clone, S: Clone> Clone for ContentsView<K, V, S> {
+    fn clone(&self) -> Self {
+        Self {
+            map: self.map.clone(),
+        }
+    }
+}
+
+impl<K: Eq + Hash + fmt::Debug, V: fmt::Debug, S: BuildHasher + Clone> fmt::Debug
+    for ContentsView<K, V, S>
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.map.fmt(f)
+    }
+}
+
+impl<K, V, S> ContentsView<K, V, S> {
+    pub(crate) fn new(map: DashMap<K, V, S>) -> Self {
+        Self { map }
+    }
+
+    /// Consumes this `ContentsView`, returning the underlying `DashMap`.
+    pub fn into_inner(self) -> DashMap<K, V, S> {
+        self.map
+    }
+}
+
+impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> ContentsView<K, V, S> {
+    /// Returns the number of elements in the map.
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    /// Returns `true` if the map contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    /// Returns the number of elements the map can hold without reallocating.
+    pub fn capacity(&self) -> usize {
+        self.map.capacity()
+    }
+
+    /// Returns `true` if the map contains a value for the specified key.
+    pub fn contains_key<Q>(&'a self, key: &Q) -> bool
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.map.contains_key(key)
+    }
+
+    /// Returns a reference to the contents of the value corresponding to the key.
+    pub fn get<Q, B>(&'a self, key: &Q) -> Option<&'a B>
+    where
+        K: Borrow<Q>,
+        V: StableBorrow<B>,
+        Q: Hash + Eq + ?Sized,
+        B: ?Sized,
+    {
+        // Safety: See get_key_value().
+        self.map
+            .get(key)
+            .map(|guard| unsafe { borrow_stable(guard.value()) })
+    }
+
+    /// Returns the contents of the key-value pair corresponding to the supplied
+    /// key.
+    pub fn get_key_value<Q, C, B>(&'a self, key: &Q) -> Option<(&'a C, &'a B)>
+    where
+        K: Borrow<Q> + StableBorrow<C>,
+        V: StableBorrow<B>,
+        Q: Hash + Eq + ?Sized,
+        C: ?Sized + 'a,
+        B: ?Sized + 'a,
+    {
+        // Safety: T: StableBorrow<U> means that t.borrow() remains a valid reference as
+        // long as t is not mutated. We never mutate or drop 't' (though we may move it,
+        // which is allowed). When the DashMap is in ContentsView, methods to mutate or
+        // drop existing values are not provided. Those values may move as a result of
+        // re-allocation, but that's fine since the borrows from them are stable, as
+        // required by StableBorrow.
+        self.map
+            .get(key)
+            .map(|guard| unsafe { (borrow_stable(guard.key()), borrow_stable(guard.value())) })
+    }
+
+    /// An iterator visiting the contents of all key-value pairs in arbitrary order.
+    /// The iterator element type is `(&'a C, &'a B)`.
+    pub fn iter<C, B>(&'a self) -> impl Iterator<Item = (&'a C, &'a B)> + 'a
+    where
+        K: StableBorrow<C>,
+        V: StableBorrow<B>,
+        C: ?Sized + 'a,
+        B: ?Sized + 'a,
+    {
+        // Safety: See get_key_value().
+        self.map
+            .iter()
+            .map(|guard| unsafe { (borrow_stable(guard.key()), borrow_stable(guard.value())) })
+    }
+
+    /// An iterator visiting the contents all keys in arbitrary order. The iterator
+    /// element type is `&'a B`.
+    pub fn keys<B>(&'a self) -> impl Iterator<Item = &'a B> + 'a
+    where
+        K: StableBorrow<B>,
+        B: ?Sized + 'a,
+    {
+        // Safety: See get_key_value().
+        self.map
+            .iter()
+            .map(|guard| unsafe { borrow_stable(guard.key()) })
+    }
+
+    /// An iterator visiting all values in arbitrary order. The iterator element
+    /// type is `&'a B`.
+    pub fn values<B>(&'a self) -> impl Iterator<Item = &'a B> + 'a
+    where
+        V: StableBorrow<B>,
+        B: ?Sized + 'a,
+    {
+        // Safety: See get_key_value().
+        self.map
+            .iter()
+            .map(|guard| unsafe { borrow_stable(guard.value()) })
+    }
+
+    pub fn get_or_insert<B>(&'a self, key: K, value: V) -> &'a B
+    where
+        V: StableBorrow<B>,
+        B: ?Sized + 'a,
+    {
+        // Safety: See get_key_value().
+        match self.map.entry(key) {
+            Entry::Occupied(entry) => unsafe { borrow_stable(entry.get()) },
+            Entry::Vacant(entry) => unsafe { borrow_stable(entry.insert(value).value()) },
+        }
+    }
+
+    pub fn get_or_insert_with<B, F>(&'a self, key: K, func: F) -> &'a B
+    where
+        V: StableBorrow<B>,
+        B: ?Sized + 'a,
+        F: FnOnce(&K) -> V,
+    {
+        // Safety: See get_key_value().
+        match self.map.entry(key) {
+            Entry::Occupied(entry) => unsafe { borrow_stable(entry.get()) },
+            Entry::Vacant(entry) => unsafe {
+                let value = func(entry.key());
+                borrow_stable(entry.insert(value).value())
+            },
+        }
+    }
+}
+
+// Safety: 'value' must not be mutated for 'a
+unsafe fn borrow_stable<'a, 'b, T, B>(value: &'b T) -> &'a B
+where
+    T: StableBorrow<B> + ?Sized + 'a,
+    B: ?Sized + 'a,
+{
+    &*(value.borrow() as *const B)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::DashMap;
+    use std::borrow::Borrow;
+
+    fn construct_sample_map() -> DashMap<String, String> {
+        let map = DashMap::new();
+
+        map.insert("a".to_string(), "one".to_string());
+        map.insert("b".to_string(), "two".to_string());
+        map.insert("c".to_string(), "three".to_string());
+        map.insert("d".to_string(), "four".to_string());
+
+        map
+    }
+
+    #[test]
+    fn test_properties() {
+        let map = construct_sample_map();
+
+        let view = map.clone().into_contents_view();
+        assert_eq!(view.is_empty(), map.is_empty());
+        assert_eq!(view.len(), map.len());
+        assert_eq!(view.capacity(), map.capacity());
+
+        let new_map = view.into_inner();
+        assert_eq!(new_map.is_empty(), map.is_empty());
+        assert_eq!(new_map.len(), map.len());
+        assert_eq!(new_map.capacity(), map.capacity());
+    }
+
+    #[test]
+    fn test_get() {
+        let map = construct_sample_map();
+        let view = map.clone().into_contents_view();
+
+        for guard in map.iter() {
+            let key = guard.key();
+            let value = guard.value();
+
+            assert!(view.contains_key(key));
+            assert_eq!(Some(value.borrow()), view.get(key));
+            assert_eq!(
+                Some((key.borrow(), value.borrow())),
+                view.get_key_value(key)
+            );
+        }
+
+        assert_eq!(
+            view.get_or_insert("a".to_string(), "dupe".to_string()),
+            "one"
+        );
+        assert_eq!(
+            view.get_or_insert("e".to_string(), "five".to_string()),
+            "five"
+        );
+
+        for guard in map.iter() {
+            let key = guard.key();
+            let value = guard.value();
+
+            assert!(view.contains_key(key));
+            assert_eq!(Some(value.borrow()), view.get(key));
+            assert_eq!(
+                Some((key.borrow(), value.borrow())),
+                view.get_key_value(key)
+            );
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,9 @@ pub mod rayon {
     pub mod set;
 }
 
+#[cfg(feature = "contents-view")]
+mod contents_view;
+
 use cfg_if::cfg_if;
 use core::borrow::Borrow;
 use core::fmt;
@@ -33,6 +36,9 @@ pub use read_only::ReadOnlyView;
 pub use set::DashSet;
 use std::collections::hash_map::RandomState;
 pub use t::Map;
+
+#[cfg(feature = "contents-view")]
+pub use contents_view::ContentsView;
 
 cfg_if! {
     if #[cfg(feature = "raw-api")] {
@@ -132,6 +138,11 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     /// Wraps this `DashMap` into a read-only view. This view allows to obtain raw references to the stored values.
     pub fn into_read_only(self) -> ReadOnlyView<K, V, S> {
         ReadOnlyView::new(self)
+    }
+
+    #[cfg(feature = "contents-view")]
+    pub fn into_contents_view(self) -> ContentsView<K, V, S> {
+        ContentsView::new(self)
     }
 
     /// Creates a new DashMap with a capacity of 0 and the provided hasher.


### PR DESCRIPTION
Hello,

I'm sending this along as a rough draft to spark discussion. Thank you for any time that you spend considering this proposal.

The change description follows, proceeded by an explanation of the underlying motivation for the change.

    The ContentsView type allows raw, immutable access to values borrowed
    from the contents of the DashMap while also permitting concurrent write
    operations which do not mutate or remove existing keys.

    The stable_borrow crate (https://gitlab.com/nwsharp/stable_borrow) is
    used to provide the guarantee necessary to enable concurrent
    re-allocations that may be caused by inserting into the DashMap. This
    crate is available under the MIT license.

    This changeset has passed 'cargo miri test -- -Zmiri-disable-isolation'.

One immediate use case for this functionality is for using `DashMap<String, ()>` for concurrent String interning. AFAIK, this would immediately result in the fastest (concurrent) String interner on crates.io, since the interned values can be pointers instead of indexes and because DashMap is highly concurrent. This is a useful property for inclusion in parallel compilers, which is what motivated me to develop this in the first place.

If you'd like more information, please don't hesitate to ask. What I've included here is quite terse.

Thank you again for your time.
