### PR TITLE
support Serde and FromIterator for custom hashers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -898,9 +898,9 @@ impl<K: Eq + Hash, V, S: BuildHasher + Clone> Extend<(K, V)> for DashMap<K, V, S
     }
 }
 
-impl<K: Eq + Hash, V> FromIterator<(K, V)> for DashMap<K, V, RandomState> {
+impl<K: Eq + Hash, V, S: BuildHasher + Clone + Default> FromIterator<(K, V)> for DashMap<K, V, S> {
     fn from_iter<I: IntoIterator<Item = (K, V)>>(intoiter: I) -> Self {
-        let mut map = DashMap::new();
+        let mut map = DashMap::default();
 
         map.extend(intoiter);
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -403,9 +403,9 @@ impl<K: Eq + Hash, S: BuildHasher + Clone> Extend<K> for DashSet<K, S> {
     }
 }
 
-impl<K: Eq + Hash> FromIterator<K> for DashSet<K, RandomState> {
+impl<K: Eq + Hash, S: BuildHasher + Clone + Default> FromIterator<K> for DashSet<K, S> {
     fn from_iter<I: IntoIterator<Item = K>>(iter: I) -> Self {
-        let mut set = DashSet::new();
+        let mut set = DashSet::default();
 
         set.extend(iter);
 


### PR DESCRIPTION
We are using DashMap `v3` and would like to migrate to `v4`. However, `v4` uses `std::collections::hash_map::RandomState`, which is slower than one `v3` uses (`ahash::RandomState`). When I parametrize DashMap with custom hasher, `serde` and `core::iter::FromIterator` don't work anymore.

This PR is attempt to fix this (it just implements these over generic DashMap).

resolves #130 