### PR TITLE
Implement Clone to Iter

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -118,6 +118,12 @@ pub struct Iter<'a, K, V, S = RandomState, M = DashMap<K, V, S>> {
     current: Option<GuardIter<'a, K, V, S>>,
 }
 
+impl<'a, 'i, K: Clone + Hash + Eq, V: Clone, S: Clone + BuildHasher> Clone for Iter<'i, K, V, S> {
+    fn clone(&self) -> Self {
+        Iter::new(self.map)
+    }
+}
+
 unsafe impl<'a, 'i, K, V, S, M> Send for Iter<'i, K, V, S, M>
 where
     K: 'a + Eq + Hash + Send,


### PR DESCRIPTION
Unsure if `V` should implement `Hash` and `Eq` as well, review needed for this.
This is being done so `serenity::cache::MessageIterator` can keep the Clone implement with the new DashMap cache rewrite that I'm working on.

	modified:   src/iter.rs