### PR TITLE
Add remove_if_mut for Map.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,6 +361,14 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
         self._remove_if(key, f)
     }
 
+    pub fn remove_if_mut<Q>(&self, key: &Q, f: impl FnOnce(&K, &mut V) -> bool) -> Option<(K, V)>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self._remove_if_mut(key, f)
+    }
+
     /// Creates an iterator over a DashMap yielding immutable references.
     ///
     /// **Locking behaviour:** May deadlock if called when holding a mutable reference into the map.
@@ -675,6 +683,34 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
                 shard.remove_entry(key).map(|(k, v)| (k, v.into_inner()))
             } else {
                 None
+            }
+        } else {
+            None
+        }
+    }
+
+    fn _remove_if_mut<Q>(&self, key: &Q, f: impl FnOnce(&K, &mut V) -> bool) -> Option<(K, V)>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        let hash = self.hash_usize(&key);
+
+        let idx = self.determine_shard(hash);
+
+        let mut shard = unsafe { self._yield_write_shard(idx) };
+
+        if let Some((kptr, vptr)) = shard.get_key_value(&key) {
+            unsafe {
+                let kptr = util::change_lifetime_const(kptr);
+
+                let vptr = &mut *vptr.as_ptr();
+
+                if f(kptr, vptr) {
+                    shard.remove_entry(key).map(|(k, v)| (k, v.into_inner()))
+                } else {
+                    None
+                }
             }
         } else {
             None

--- a/src/t.rs
+++ b/src/t.rs
@@ -39,6 +39,11 @@ pub trait Map<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + Clone + BuildHasher> {
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized;
 
+    fn _remove_if_mut<Q>(&self, key: &Q, f: impl FnOnce(&K, &mut V) -> bool) -> Option<(K, V)>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized;
+
     fn _iter(&'a self) -> Iter<'a, K, V, S, Self>
     where
         Self: Sized;


### PR DESCRIPTION
Greetings!

Maybe I want to do something stupid, but here I come. I'm writing some subscribe / unsubscribe code and storing subscribers into HashMap with counter. When someone unsubscribes I'm decreasing counter and if counter reach zero entry is removing.

With RwLock it looks like this:
```rust
use std::{collections::HashMap, sync::RwLock};

struct Value {
    counter: usize,
}

fn main() {
    let map = RwLock::new(HashMap::from([("0".to_owned(), Value { counter: 1 })]));

    {
        let mut map = map.write().unwrap();

        if let Some(Value { counter }) = map.get_mut("0") {
            *counter -= 1;
            if *counter == 0 {
                println!("last");
                map.remove("0");
            }
        }
    }

    println!("END");
}
```

Obvious with a lot of parallels sub / unsub events lock will be a bottleneck.
I can use `remove_if`, but because of deadlock I must drop `guard` and hypothetically parallelly something can happen and data will change.
```rust
    let map = DashMap::from_iter([("0".to_owned(), Value { counter: 1 })].into_iter());

    if let Some(mut guard) = map.get_mut("0") {
        let Value { counter } = guard.value_mut();
        *counter -= 1;
        if *counter == 0 {
            println!("last");
            drop(guard);
            map.remove("0");
        }
    }
```

Next option is use `Atomic` for counter with `remove_if`:
```rust
struct Value {
    counter: AtomicUsize,
}
<...>
    let is_last = map
        .remove_if("0", |_k, v| v.counter.fetch_sub(1, Ordering::Relaxed) == 1)
        .is_some();

    if is_last {
        println!("last");
    }
```
But in this case, we unnecessarily use atomic because `remove_if` have guard.

So here comes this PR:
```rust
struct Value {
    counter: usize,
}
<...>
    let is_last = map
        .remove_if_mut("0", |_k, v| {
            v.counter -= 1;
            v.counter == 0
        })
        .is_some();
```