### PR TITLE
Attempt to fix reference smuggling in Ref structs.

### DIFF
--- a/src/mapref/multiple.rs
+++ b/src/mapref/multiple.rs
@@ -33,15 +33,15 @@ impl<'a, K: Eq + Hash, V, S: BuildHasher> RefMulti<'a, K, V, S> {
         }
     }
 
-    pub fn key(&self) -> &'a K {
+    pub fn key(&self) -> &K {
         self.k
     }
 
-    pub fn value(&self) -> &'a V {
+    pub fn value(&self) -> &V {
         self.v
     }
 
-    pub fn pair(&self) -> (&'a K, &'a V) {
+    pub fn pair(&self) -> (&K, &V) {
         (self.k, self.v)
     }
 }
@@ -82,7 +82,7 @@ impl<'a, K: Eq + Hash, V, S: BuildHasher> RefMutMulti<'a, K, V, S> {
         }
     }
 
-    pub fn key(&self) -> &'a K {
+    pub fn key(&self) -> &K {
         self.k
     }
 
@@ -94,11 +94,11 @@ impl<'a, K: Eq + Hash, V, S: BuildHasher> RefMutMulti<'a, K, V, S> {
         self.v
     }
 
-    pub fn pair(&self) -> (&'a K, &V) {
+    pub fn pair(&self) -> (&K, &V) {
         (self.k, self.v)
     }
 
-    pub fn pair_mut(&mut self) -> (&'a K, &mut V) {
+    pub fn pair_mut(&mut self) -> (&K, &mut V) {
         (self.k, self.v)
     }
 }

--- a/src/mapref/one.rs
+++ b/src/mapref/one.rs
@@ -27,15 +27,15 @@ impl<'a, K: Eq + Hash, V, S: BuildHasher> Ref<'a, K, V, S> {
         }
     }
 
-    pub fn key(&self) -> &'a K {
+    pub fn key(&self) -> &K {
         self.k
     }
 
-    pub fn value(&self) -> &'a V {
+    pub fn value(&self) -> &V {
         self.v
     }
 
-    pub fn pair(&self) -> (&'a K, &'a V) {
+    pub fn pair(&self) -> (&K, &V) {
         (self.k, self.v)
     }
 }
@@ -72,7 +72,7 @@ impl<'a, K: Eq + Hash, V, S: BuildHasher> RefMut<'a, K, V, S> {
         Self { guard, k, v }
     }
 
-    pub fn key(&self) -> &'a K {
+    pub fn key(&self) -> &K {
         self.k
     }
 
@@ -84,11 +84,11 @@ impl<'a, K: Eq + Hash, V, S: BuildHasher> RefMut<'a, K, V, S> {
         self.v
     }
 
-    pub fn pair(&self) -> (&'a K, &V) {
+    pub fn pair(&self) -> (&K, &V) {
         (self.k, self.v)
     }
 
-    pub fn pair_mut(&mut self) -> (&'a K, &mut V) {
+    pub fn pair_mut(&mut self) -> (&K, &mut V) {
         (self.k, self.v)
     }
 

--- a/src/setref/multiple.rs
+++ b/src/setref/multiple.rs
@@ -11,7 +11,7 @@ impl<'a, K: Eq + Hash, S: BuildHasher> RefMulti<'a, K, S> {
         Self { inner }
     }
 
-    pub fn key(&self) -> &'a K {
+    pub fn key(&self) -> &K {
         self.inner.key()
     }
 }

--- a/src/setref/one.rs
+++ b/src/setref/one.rs
@@ -15,7 +15,7 @@ impl<'a, K: Eq + Hash, S: BuildHasher> Ref<'a, K, S> {
         Self { inner }
     }
 
-    pub fn key(&self) -> &'a K {
+    pub fn key(&self) -> &K {
         self.inner.key()
     }
 }


### PR DESCRIPTION
This is an attempt to fix #167 - as far as I can tell, both key and value references exhibit UB when not scoped to the (elided) lifetime of self in these functions.  This is a breaking change, even if only for cases where these functions were causing UB in dependent code.

I'm marking this as a draft because I don't fully understand the API for the Ref structs outside of the reference smuggling I found in my own testing, and because there may be other desired ways to resolve this and/or other parts of the codebase affected by this issue that I didn't catch looking over the sources.