### PR TITLE
Add support for setting shard amount.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["concurrency", "algorithms", "data-structures"]
 default = ["send_guard"]
 raw-api = []
 send_guard = ["parking_lot/send_guard"]
+slow_shard_amount = []
 
 [dependencies]
 num_cpus = "1.13.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ categories = ["concurrency", "algorithms", "data-structures"]
 default = ["send_guard"]
 raw-api = []
 send_guard = ["parking_lot/send_guard"]
-slow_shard_amount = []
 
 [dependencies]
 num_cpus = "1.13.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     /// mappings.insert(2, 4);
     /// mappings.insert(8, 16);
     /// ```
-    pub fn with_capacity_and_hasher(mut capacity: usize, hasher: S) -> Self {
+    pub fn with_capacity_and_hasher(capacity: usize, hasher: S) -> Self {
         Self::with_capacity_and_hasher_and_shard_amount(capacity, hasher, default_shard_amount())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,11 @@ impl<'a, K: 'a + Eq + Hash, V: 'a> DashMap<K, V, RandomState> {
     }
 
     /// Creates a new DashMap with a specified shard amount
+    /// 
+    /// shard_amount should greater than 0 and be a power of two. 
+    /// If a shard_amount which is not a power of two is provided, the function will panic.
+    /// To use a shard_amount not a power of two, you should have `slow_shard_amount` feature enabled.
+    /// 
     /// # Examples
     ///
     /// ```
@@ -142,7 +147,12 @@ impl<'a, K: 'a + Eq + Hash, V: 'a> DashMap<K, V, RandomState> {
         Self::with_capacity_and_hasher_and_shard_amount(0, RandomState::default(), shard_amount)
     }
 
-    /// Creates a new DashMap with a specified shard amount and capacity
+    /// Creates a new DashMap with a specified capacity and shard amount.
+    /// 
+    /// shard_amount should greater than 0 and be a power of two. 
+    /// If a shard_amount which is not a power of two is provided, the function will panic.
+    /// To use a shard_amount not a power of two, you should have `slow_shard_amount` feature enabled.
+    /// 
     /// # Examples
     ///
     /// ```
@@ -197,6 +207,11 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     }
 
     /// Creates a new DashMap with a specified hasher and shard amount
+    /// 
+    /// shard_amount should greater than 0 and be a power of two. 
+    /// If a shard_amount which is not a power of two is provided, the function will panic.
+    /// To use a shard_amount not a power of two, you should have `slow_shard_amount` feature enabled.
+    /// 
     /// # Examples
     ///
     /// ```
@@ -214,8 +229,10 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
 
     /// Creates a new DashMap with a specified starting capacity, hasher and shard_amount.
     /// 
-    /// shard_amount should greater than 0.
-    ///
+    /// shard_amount should greater than 0 and be a power of two. 
+    /// If a shard_amount which is not a power of two is provided, the function will panic.
+    /// To use a shard_amount not a power of two, you should have `slow_shard_amount` feature enabled.
+    /// 
     /// # Examples
     ///
     /// ```
@@ -229,6 +246,13 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     /// ```
     pub fn with_capacity_and_hasher_and_shard_amount(mut capacity: usize, hasher: S, shard_amount: usize) -> Self {
         assert!(shard_amount > 0);
+
+        cfg_if!(
+            if #[cfg(not(feature = "slow_shard_amount"))] {
+                assert!(shard_amount == shard_amount.next_power_of_two());
+            }
+        );
+
         let shift = util::ptr_size_bits() - ncb(shard_amount);
 
         if capacity != 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,10 +129,10 @@ impl<'a, K: 'a + Eq + Hash, V: 'a> DashMap<K, V, RandomState> {
     }
 
     /// Creates a new DashMap with a specified shard amount
-    /// 
-    /// shard_amount should greater than 0 and be a power of two. 
+    ///
+    /// shard_amount should greater than 0 and be a power of two.
     /// If a shard_amount which is not a power of two is provided, the function will panic.
-    /// 
+    ///
     /// # Examples
     ///
     /// ```
@@ -147,10 +147,10 @@ impl<'a, K: 'a + Eq + Hash, V: 'a> DashMap<K, V, RandomState> {
     }
 
     /// Creates a new DashMap with a specified capacity and shard amount.
-    /// 
-    /// shard_amount should greater than 0 and be a power of two. 
+    ///
+    /// shard_amount should greater than 0 and be a power of two.
     /// If a shard_amount which is not a power of two is provided, the function will panic.
-    /// 
+    ///
     /// # Examples
     ///
     /// ```
@@ -161,7 +161,11 @@ impl<'a, K: 'a + Eq + Hash, V: 'a> DashMap<K, V, RandomState> {
     /// mappings.insert(8, 16);
     /// ```
     pub fn with_capacity_and_shard_amount(capacity: usize, shard_amount: usize) -> Self {
-        Self::with_capacity_and_hasher_and_shard_amount(capacity, RandomState::default(), shard_amount)
+        Self::with_capacity_and_hasher_and_shard_amount(
+            capacity,
+            RandomState::default(),
+            shard_amount,
+        )
     }
 }
 
@@ -205,10 +209,10 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     }
 
     /// Creates a new DashMap with a specified hasher and shard amount
-    /// 
-    /// shard_amount should greater than 0 and be a power of two. 
+    ///
+    /// shard_amount should greater than 0 and be a power of two.
     /// If a shard_amount which is not a power of two is provided, the function will panic.
-    /// 
+    ///
     /// # Examples
     ///
     /// ```
@@ -225,10 +229,10 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     }
 
     /// Creates a new DashMap with a specified starting capacity, hasher and shard_amount.
-    /// 
-    /// shard_amount should greater than 0 and be a power of two. 
+    ///
+    /// shard_amount should greater than 0 and be a power of two.
     /// If a shard_amount which is not a power of two is provided, the function will panic.
-    /// 
+    ///
     /// # Examples
     ///
     /// ```
@@ -240,7 +244,11 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     /// mappings.insert(2, 4);
     /// mappings.insert(8, 16);
     /// ```
-    pub fn with_capacity_and_hasher_and_shard_amount(mut capacity: usize, hasher: S, shard_amount: usize) -> Self {
+    pub fn with_capacity_and_hasher_and_shard_amount(
+        mut capacity: usize,
+        hasher: S,
+        shard_amount: usize,
+    ) -> Self {
         assert!(shard_amount > 0);
 
         let shift = util::ptr_size_bits() - ncb(shard_amount);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,6 @@ impl<'a, K: 'a + Eq + Hash, V: 'a> DashMap<K, V, RandomState> {
     /// 
     /// shard_amount should greater than 0 and be a power of two. 
     /// If a shard_amount which is not a power of two is provided, the function will panic.
-    /// To use a shard_amount not a power of two, you should have `slow_shard_amount` feature enabled.
     /// 
     /// # Examples
     ///
@@ -151,7 +150,6 @@ impl<'a, K: 'a + Eq + Hash, V: 'a> DashMap<K, V, RandomState> {
     /// 
     /// shard_amount should greater than 0 and be a power of two. 
     /// If a shard_amount which is not a power of two is provided, the function will panic.
-    /// To use a shard_amount not a power of two, you should have `slow_shard_amount` feature enabled.
     /// 
     /// # Examples
     ///
@@ -210,7 +208,6 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     /// 
     /// shard_amount should greater than 0 and be a power of two. 
     /// If a shard_amount which is not a power of two is provided, the function will panic.
-    /// To use a shard_amount not a power of two, you should have `slow_shard_amount` feature enabled.
     /// 
     /// # Examples
     ///
@@ -231,7 +228,6 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     /// 
     /// shard_amount should greater than 0 and be a power of two. 
     /// If a shard_amount which is not a power of two is provided, the function will panic.
-    /// To use a shard_amount not a power of two, you should have `slow_shard_amount` feature enabled.
     /// 
     /// # Examples
     ///
@@ -246,12 +242,6 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     /// ```
     pub fn with_capacity_and_hasher_and_shard_amount(mut capacity: usize, hasher: S, shard_amount: usize) -> Self {
         assert!(shard_amount > 0);
-
-        cfg_if!(
-            if #[cfg(not(feature = "slow_shard_amount"))] {
-                assert!(shard_amount == shard_amount.next_power_of_two());
-            }
-        );
 
         let shift = util::ptr_size_bits() - ncb(shard_amount);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a> DashMap<K, V, RandomState> {
     /// ```
     /// use dashmap::DashMap;
     ///
-    /// let mappings = DashMap::with_shard_amount(10);
+    /// let mappings = DashMap::with_shard_amount(32);
     /// mappings.insert(2, 4);
     /// mappings.insert(8, 16);
     /// ```
@@ -158,7 +158,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a> DashMap<K, V, RandomState> {
     /// ```
     /// use dashmap::DashMap;
     ///
-    /// let mappings = DashMap::with_capacity_and_shard_amount(32, 10);
+    /// let mappings = DashMap::with_capacity_and_shard_amount(32, 32);
     /// mappings.insert(2, 4);
     /// mappings.insert(8, 16);
     /// ```
@@ -219,7 +219,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     /// use std::collections::hash_map::RandomState;
     ///
     /// let s = RandomState::new();
-    /// let mappings = DashMap::with_hasher_and_shard_amount(s, 10);
+    /// let mappings = DashMap::with_hasher_and_shard_amount(s, 32);
     /// mappings.insert(2, 4);
     /// mappings.insert(8, 16);
     /// ```
@@ -240,7 +240,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     /// use std::collections::hash_map::RandomState;
     ///
     /// let s = RandomState::new();
-    /// let mappings = DashMap::with_capacity_and_hasher_and_shard_amount(2, s, 10);
+    /// let mappings = DashMap::with_capacity_and_hasher_and_shard_amount(2, s, 32);
     /// mappings.insert(2, 4);
     /// mappings.insert(8, 16);
     /// ```


### PR DESCRIPTION
This PR adds support for setting a shard amount when initializing a `DashMap`. If not specified, the default shard amount calculated by CPU cores will be used.
