### PR TITLE
VacantEntry/OccupiedEntry default type for S

### DIFF
--- a/src/mapref/entry.rs
+++ b/src/mapref/entry.rs
@@ -84,7 +84,7 @@ impl<'a, K: Eq + Hash, V, S: BuildHasher> Entry<'a, K, V, S> {
     }
 }
 
-pub struct VacantEntry<'a, K, V, S> {
+pub struct VacantEntry<'a, K, V, S = RandomState> {
     shard: RwLockWriteGuard<'a, HashMap<K, V, S>>,
     key: K,
 }
@@ -130,7 +130,7 @@ impl<'a, K: Eq + Hash, V, S: BuildHasher> VacantEntry<'a, K, V, S> {
     }
 }
 
-pub struct OccupiedEntry<'a, K, V, S> {
+pub struct OccupiedEntry<'a, K, V, S = RandomState> {
     shard: RwLockWriteGuard<'a, HashMap<K, V, S>>,
     elem: (*const K, *mut V),
     key: K,


### PR DESCRIPTION
`Entry<K, V, S>` can be used without specifying type of `S`, as
`Entry<K, V>`.

Do the same for `VacantEntry` and `OccupiedEntry`.