### PR TITLE
Tune hashbrown feature set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ raw-api = []
 
 [dependencies]
 lock_api = "0.4.7"
-hashbrown = "0.12.0"
+hashbrown = { version = "0.12.0", default-features = false }
 serde = { version = "1.0.136", optional = true, features = ["derive"] }
 cfg-if = "1.0.0"
 rayon = { version = "1.5.2", optional = true }


### PR DESCRIPTION
Removes the transient dependency on `ahash`.
