### PR TITLE
Set rust-version to 1.59

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "dashmap"
 version = "5.3.3"
 authors = ["Acrimon <joel.wejdenstal@gmail.com>"]
 edition = "2018"
+rust-version = "1.59"
 license = "MIT"
 repository = "https://github.com/xacrimon/dashmap"
 homepage = "https://github.com/xacrimon/dashmap"


### PR DESCRIPTION
This crate uses available_parallelism which was introduced in Rust 1.59.

`rust-version` is a field for indicating MSRV: https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field