### PR TITLE
Switch hashbrown to std::collections::hash_map

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ raw-api = []
 [dependencies]
 lock_api = "0.4.7"
 parking_lot_core = "0.9.3"
-hashbrown = { version = "0.12.0", default-features = false }
 serde = { version = "1.0.136", optional = true, features = ["derive"] }
 cfg-if = "1.0.0"
 rayon = { version = "1.5.2", optional = true }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -6,8 +6,7 @@ use crate::util::SharedValue;
 use crate::{DashMap, HashMap};
 use core::hash::{BuildHasher, Hash};
 use core::mem;
-use hashbrown::hash_map;
-use std::collections::hash_map::RandomState;
+use std::collections::hash_map::{self, RandomState};
 use std::sync::Arc;
 
 /// Iterator over a DashMap yielding key value pairs.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ use mapref::multiple::RefMulti;
 use mapref::one::{Ref, RefMut};
 pub use read_only::ReadOnlyView;
 pub use set::DashSet;
-use std::collections::hash_map::RandomState;
+use std::collections::hash_map::{self, RandomState};
 pub use t::Map;
 use try_result::TryResult;
 
@@ -49,7 +49,7 @@ cfg_if! {
     }
 }
 
-pub(crate) type HashMap<K, V, S> = hashbrown::HashMap<K, SharedValue<V>, S>;
+pub(crate) type HashMap<K, V, S> = hash_map::HashMap<K, SharedValue<V>, S>;
 
 fn default_shard_amount() -> usize {
     (std::thread::available_parallelism().map_or(1, usize::from) * 4).next_power_of_two()


### PR DESCRIPTION
The `std::collections::hash_map` implementation was replaced with a copy of `hashbrown` in Rust 1.36. There’s still a difference in the default hasher, but we disabled that default in #205. So I think this switch has no effect but to improve compile times and binary sizes.