### PR TITLE
Implement ExactSizeIterator on structs that implement Iterator

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,21 +1,14 @@
-use core::{
-    hash::{BuildHasher, Hash},
-    mem,
-};
-use std::{collections::hash_map::RandomState, sync::Arc};
-
+use super::mapref::multiple::{RefMulti, RefMutMulti};
+use super::util;
+use crate::lock::{RwLockReadGuard, RwLockWriteGuard};
+use crate::t::Map;
+use crate::util::SharedValue;
+use crate::{DashMap, HashMap};
+use core::hash::{BuildHasher, Hash};
+use core::mem;
 use hashbrown::hash_map;
-
-use super::{
-    mapref::multiple::{RefMulti, RefMutMulti},
-    util,
-};
-use crate::{
-    lock::{RwLockReadGuard, RwLockWriteGuard},
-    t::Map,
-    util::SharedValue,
-    DashMap, HashMap,
-};
+use std::collections::hash_map::RandomState;
+use std::sync::Arc;
 
 /// Iterator over a DashMap yielding key value pairs.
 ///
@@ -63,7 +56,7 @@ impl<K: Eq + Hash, V, S: BuildHasher + Clone> Iterator for OwningIter<K, V, S> {
                 return None;
             }
 
-            // let guard = unsafe { self.map._yield_read_shard(self.shard_i) };
+            //let guard = unsafe { self.map._yield_read_shard(self.shard_i) };
             let mut shard_wl = unsafe { self.map._yield_write_shard(self.shard_i) };
 
             let hasher = self.map._hasher();
@@ -74,7 +67,7 @@ impl<K: Eq + Hash, V, S: BuildHasher + Clone> Iterator for OwningIter<K, V, S> {
 
             let iter = map.into_iter();
 
-            // unsafe { ptr::write(&mut self.current, Some((arcee, iter))); }
+            //unsafe { ptr::write(&mut self.current, Some((arcee, iter))); }
             self.current = Some(iter);
 
             self.shard_i += 1;

--- a/src/iter_set.rs
+++ b/src/iter_set.rs
@@ -1,6 +1,6 @@
-use crate::setref::multiple::RefMulti;
-use crate::t::Map;
 use core::hash::{BuildHasher, Hash};
+
+use crate::{setref::multiple::RefMulti, t::Map};
 
 pub struct OwningIter<K, S> {
     inner: crate::iter::OwningIter<K, (), S>,
@@ -17,6 +17,12 @@ impl<K: Eq + Hash, S: BuildHasher + Clone> Iterator for OwningIter<K, S> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next().map(|(k, _)| k)
+    }
+}
+
+impl<K: Eq + Hash, S: BuildHasher + Clone> ExactSizeIterator for OwningIter<K, S> {
+    fn len(&self) -> usize {
+        self.inner.len()
     }
 }
 
@@ -67,5 +73,13 @@ impl<'a, K: Eq + Hash, S: 'a + BuildHasher + Clone, M: Map<'a, K, (), S>> Iterat
 
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next().map(RefMulti::new)
+    }
+}
+
+impl<'a, K: Eq + Hash, S: 'a + BuildHasher + Clone, M: Map<'a, K, (), S>> ExactSizeIterator
+    for Iter<'a, K, S, M>
+{
+    fn len(&self) -> usize {
+        self.inner.len()
     }
 }

--- a/src/iter_set.rs
+++ b/src/iter_set.rs
@@ -1,6 +1,6 @@
+use crate::setref::multiple::RefMulti;
+use crate::t::Map;
 use core::hash::{BuildHasher, Hash};
-
-use crate::{setref::multiple::RefMulti, t::Map};
 
 pub struct OwningIter<K, S> {
     inner: crate::iter::OwningIter<K, (), S>,


### PR DESCRIPTION
I'm not sure if it's possible to do the same for rayon's iterators but this is useful for cases where you don't want to expose the inner map but just the iterator itself, or where you simply don't have access to the inner map since it's a private field with no getter (Why wasn't that implemented?)