### PR TITLE
feat: memoize default shard amount

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ hashbrown = { version = "0.12.0", default-features = false }
 serde = { version = "1.0.136", optional = true, features = ["derive"] }
 cfg-if = "1.0.0"
 rayon = { version = "1.5.2", optional = true }
+once_cell = "1.13.0"
 
 [package.metadata.docs.rs]
 features = ["rayon", "raw-api", "serde"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ use iter::{Iter, IterMut, OwningIter};
 use mapref::entry::{Entry, OccupiedEntry, VacantEntry};
 use mapref::multiple::RefMulti;
 use mapref::one::{Ref, RefMut};
+use once_cell::sync::OnceCell;
 pub use read_only::ReadOnlyView;
 pub use set::DashSet;
 use std::collections::hash_map::RandomState;
@@ -52,7 +53,10 @@ cfg_if! {
 pub(crate) type HashMap<K, V, S> = hashbrown::HashMap<K, SharedValue<V>, S>;
 
 fn default_shard_amount() -> usize {
-    (std::thread::available_parallelism().map_or(1, usize::from) * 4).next_power_of_two()
+    static DEFAULT_SHARD_AMOUNT: OnceCell<usize> = OnceCell::new();
+    *DEFAULT_SHARD_AMOUNT.get_or_init(|| {
+        (std::thread::available_parallelism().map_or(1, usize::from) * 4).next_power_of_two()
+    })
 }
 
 fn ncb(shard_amount: usize) -> usize {


### PR DESCRIPTION
Closes https://github.com/xacrimon/dashmap/issues/219.

Use `once_cell` crate to memoize the value.
This doesn't add any new dependencies, as `once_cell` was already a subdependency. Additionally, it was merged into std in nightly and is awaiting stabilization.