### PR TITLE
Entry insert

### DIFF
--- a/src/mapref/entry.rs
+++ b/src/mapref/entry.rs
@@ -82,7 +82,24 @@ impl<'a, K: Eq + Hash, V, S: BuildHasher> Entry<'a, K, V, S> {
             Entry::Vacant(entry) => Ok(entry.insert(value()?)),
         }
     }
+
+    /// Sets the value of the entry, and returns a reference to the inserted value.
+    pub fn insert(self, value: V) -> RefMut<'a, K, V, S> {
+        match self {
+            Entry::Occupied(mut entry) => {
+                entry.insert(value);
+                entry.into_ref()
+            }
+            Entry::Vacant(entry) => entry.insert(value),
+        }
+    }
+
     /// Sets the value of the entry, and returns an OccupiedEntry.
+    ///
+    /// If you are not interested in the occupied entry,
+    /// consider [`insert`] as it doesn't need to clone the key.
+    /// 
+    /// [`insert`]: Entry::insert
     pub fn insert_entry(self, value: V) -> OccupiedEntry<'a, K, V, S> where K: Clone {
         match self {
             Entry::Occupied(mut entry) => {

--- a/src/mapref/entry.rs
+++ b/src/mapref/entry.rs
@@ -82,6 +82,16 @@ impl<'a, K: Eq + Hash, V, S: BuildHasher> Entry<'a, K, V, S> {
             Entry::Vacant(entry) => Ok(entry.insert(value()?)),
         }
     }
+    /// Sets the value of the entry, and returns an OccupiedEntry.
+    pub fn insert_entry(self, value: V) -> OccupiedEntry<'a, K, V, S> where K: Clone {
+        match self {
+            Entry::Occupied(mut entry) => {
+                entry.insert(value);
+                entry
+            }
+            Entry::Vacant(entry) => entry.insert_entry(value),
+        }
+    }
 }
 
 pub struct VacantEntry<'a, K, V, S = RandomState> {
@@ -112,6 +122,21 @@ impl<'a, K: Eq + Hash, V, S: BuildHasher> VacantEntry<'a, K, V, S> {
             let r = RefMut::new(self.shard, k, v);
 
             mem::forget(c);
+
+            r
+        }
+    }
+
+    /// Sets the value of the entry with the VacantEntry’s key, and returns an OccupiedEntry.
+    pub fn insert_entry(mut self, value: V) -> OccupiedEntry<'a, K, V, S> where K: Clone {
+        unsafe {
+            self.shard.insert(self.key.clone(), SharedValue::new(value));
+
+            let (k, v) = self.shard.get_key_value(&self.key).unwrap();
+
+            let kptr: *const K = k;
+            let vptr: *mut V = v.as_ptr();
+            let r = OccupiedEntry::new(self.shard, self.key, (kptr, vptr));
 
             r
         }
@@ -185,5 +210,50 @@ impl<'a, K: Eq + Hash, V, S: BuildHasher> OccupiedEntry<'a, K, V, S> {
         let (k, v) = self.shard.remove_entry(key).unwrap();
         self.shard.insert(nk, SharedValue::new(value));
         (k, v.into_inner())
+    }
+}
+
+
+
+#[cfg(test)]
+mod tests {
+    use crate::DashMap;
+
+    use super::*;
+
+    #[test]
+    fn test_insert_entry_into_vacant() {
+        let map: DashMap<u32, u32> = DashMap::new();
+
+        let entry = map.entry(1);
+
+        assert!(matches!(entry, Entry::Vacant(_)));
+        
+        let entry = entry.insert_entry(2);
+
+        assert_eq!(*entry.get(), 2);
+
+        drop(entry);
+
+        assert_eq!(*map.get(&1).unwrap(), 2);
+    }
+
+    #[test]
+    fn test_insert_entry_into_occupied() {
+        let map: DashMap<u32, u32> = DashMap::new();
+
+        map.insert(1, 1000);
+
+        let entry = map.entry(1);
+
+        assert!(matches!(&entry, Entry::Occupied(entry) if *entry.get() == 1000));
+        
+        let entry = entry.insert_entry(2);
+
+        assert_eq!(*entry.get(), 2);
+
+        drop(entry);
+
+        assert_eq!(*map.get(&1).unwrap(), 2);
     }
 }


### PR DESCRIPTION
1. Added `VacantEntry::insert_entry` [as in the std](https://doc.rust-lang.org/std/collections/hash_map/struct.VacantEntry.html#method.insert_entry).
2. Added `Entry::insert_entry` [as in the std](https://doc.rust-lang.org/std/collections/hash_map/enum.Entry.html#method.insert_entry).

Unfortunately I was not able to achieve this without requiring the key `K` to be `Clone`, but I think it's better than nothing.
For cases where the key is not `Clone` or shouldn't be cloned, I ...

3. ... added `Entry::insert`, which makes sense to me, but is not a function in the std.