### PR TITLE
Use std HashMap.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,10 @@ categories = ["concurrency", "algorithms", "data-structures"]
 
 [features]
 raw-api = []
-inline = ["hashbrown/inline-more"]
 
 [dependencies]
 lock_api = "0.4.8"
 parking_lot_core = "0.9.3"
-hashbrown = { version = "0.12.3", default-features = false }
 serde = { version = "1.0.144", optional = true, features = ["derive"] }
 cfg-if = "1.0.0"
 rayon = { version = "1.5.3", optional = true }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -6,8 +6,7 @@ use crate::util::SharedValue;
 use crate::{DashMap, HashMap};
 use core::hash::{BuildHasher, Hash};
 use core::mem;
-use hashbrown::hash_map;
-use std::collections::hash_map::RandomState;
+use std::collections::hash_map::{self, RandomState};
 use std::sync::Arc;
 
 /// Iterator over a DashMap yielding key value pairs.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ cfg_if! {
     }
 }
 
-pub(crate) type HashMap<K, V, S> = hashbrown::HashMap<K, SharedValue<V>, S>;
+pub(crate) type HashMap<K, V, S> = std::collections::HashMap<K, SharedValue<V>, S>;
 
 // Temporary reimplementation of [`std::collections::TryReserveError`]
 // util [`std::collections::TryReserveError`] stabilises.


### PR DESCRIPTION
Since Rust 1.36, this is now the HashMap implementation for the Rust standard library.
So there is no point in usage `hashbrown` crate.