### PR TITLE
Add optional arbitrary support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,7 @@ serde = { version = "1.0.136", optional = true, features = ["derive"] }
 cfg-if = "1.0.0"
 rayon = { version = "1.5.1", optional = true }
 
+arbitrary = { version = "1.3.0", optional = true }
+
 [package.metadata.docs.rs]
 features = ["rayon", "raw-api", "serde", "send_guard"]

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -1,0 +1,13 @@
+use arbitrary::{Arbitrary, Unstructured};
+use core::hash::BuildHasher;
+
+impl<'a, K, V, S> Arbitrary<'a> for crate::DashMap<K, V, S>
+where
+    K: Eq + std::hash::Hash + Arbitrary<'a>,
+    V: Arbitrary<'a>,
+    S: Default + BuildHasher + Clone,
+{
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        u.arbitrary_iter()?.collect()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::type_complexity)]
 
+#[cfg(feature = "arbitrary")]
+mod arbitrary;
 pub mod iter;
 pub mod iter_set;
 pub mod mapref;


### PR DESCRIPTION
`arbitrary` is a crate for structure-aware fuzz testing. Implementing `Arbitrary` for dashmap makes it easier to do structure-aware fuzzing of crates and structs that contain a Dashmap.

Smallvec already does something similar: https://docs.rs/crate/smallvec/latest/source/src/arbitrary.rs
so as a result this can't be added directly to arbitrary because it causes a cyclic dependency (arbitrary -> dashmap -> smallvec -> arbitrary).