### PR TITLE
Upgraded hashbrown to 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "dashmap"
 version = "5.4.0"
 authors = ["Acrimon <joel.wejdenstal@gmail.com>"]
 edition = "2018"
-rust-version = "1.59"
+rust-version = "1.64"
 license = "MIT"
 repository = "https://github.com/xacrimon/dashmap"
 homepage = "https://github.com/xacrimon/dashmap"
@@ -20,7 +20,7 @@ inline = ["hashbrown/inline-more"]
 [dependencies]
 lock_api = "0.4.8"
 parking_lot_core = "0.9.3"
-hashbrown = { version = "0.12.3", default-features = false }
+hashbrown = { version = "0.14.0", default-features = false }
 serde = { version = "1.0.144", optional = true, features = ["derive"] }
 cfg-if = "1.0.0"
 rayon = { version = "1.5.3", optional = true }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.59"
+channel = "1.64"
 components = [ "rustfmt", "clippy" ]
 profile = "minimal"


### PR DESCRIPTION
This bumps hashbrown to 0.14, which also increases the MSRV to 1.64 (September 2022). This could override #250.