### PR TITLE
refactor: replace Borrow requirement on key with hashbrown::Equivalent

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,11 +29,11 @@ use crate::lock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 pub use crate::lock::{RawRwLock, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use cfg_if::cfg_if;
-use core::borrow::Borrow;
 use core::fmt;
 use core::hash::{BuildHasher, Hash, Hasher};
 use core::iter::FromIterator;
 use core::ops::{BitAnd, BitOr, Shl, Shr, Sub};
+pub use hashbrown::Equivalent;
 use iter::{Iter, IterMut, OwningIter};
 use mapref::entry::{Entry, OccupiedEntry, VacantEntry};
 use mapref::multiple::RefMulti;
@@ -387,8 +387,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
             /// ```
             pub fn determine_map<Q>(&self, key: &Q) -> usize
             where
-                K: Borrow<Q>,
-                Q: Hash + Eq + ?Sized,
+                Q: Hash + Equivalent<K> + ?Sized,
             {
                 let hash = self.hash_usize(&key);
                 self.determine_shard(hash)
@@ -474,8 +473,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     /// ```
     pub fn remove<Q>(&self, key: &Q) -> Option<(K, V)>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Hash + Equivalent<K> + ?Sized,
     {
         self._remove(key)
     }
@@ -503,16 +501,14 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     /// ```
     pub fn remove_if<Q>(&self, key: &Q, f: impl FnOnce(&K, &V) -> bool) -> Option<(K, V)>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Hash + Equivalent<K> + ?Sized,
     {
         self._remove_if(key, f)
     }
 
     pub fn remove_if_mut<Q>(&self, key: &Q, f: impl FnOnce(&K, &mut V) -> bool) -> Option<(K, V)>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Hash + Equivalent<K> + ?Sized,
     {
         self._remove_if_mut(key, f)
     }
@@ -567,8 +563,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     /// ```
     pub fn get<Q>(&'a self, key: &Q) -> Option<Ref<'a, K, V, S>>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Hash + Equivalent<K> + ?Sized,
     {
         self._get(key)
     }
@@ -589,8 +584,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     /// ```
     pub fn get_mut<Q>(&'a self, key: &Q) -> Option<RefMut<'a, K, V, S>>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Hash + Equivalent<K> + ?Sized,
     {
         self._get_mut(key)
     }
@@ -616,8 +610,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     /// ```
     pub fn try_get<Q>(&'a self, key: &Q) -> TryResult<Ref<'a, K, V, S>>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Hash + Equivalent<K> + ?Sized,
     {
         self._try_get(key)
     }
@@ -644,8 +637,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     /// ```
     pub fn try_get_mut<Q>(&'a self, key: &Q) -> TryResult<RefMut<'a, K, V, S>>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Hash + Equivalent<K> + ?Sized,
     {
         self._try_get_mut(key)
     }
@@ -759,8 +751,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     /// If the given closure panics, then `alter` will abort the process
     pub fn alter<Q>(&self, key: &Q, f: impl FnOnce(&K, V) -> V)
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Hash + Equivalent<K> + ?Sized,
     {
         self._alter(key, f);
     }
@@ -810,8 +801,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     /// If the given closure panics, then `view` will abort the process
     pub fn view<Q, R>(&self, key: &Q, f: impl FnOnce(&K, &V) -> R) -> Option<R>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Hash + Equivalent<K> + ?Sized,
     {
         self._view(key, f)
     }
@@ -831,8 +821,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     /// ```
     pub fn contains_key<Q>(&self, key: &Q) -> bool
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Hash + Equivalent<K> + ?Sized,
     {
         self._contains_key(key)
     }
@@ -929,8 +918,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
 
     fn _remove<Q>(&self, key: &Q) -> Option<(K, V)>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Hash + Equivalent<K> + ?Sized,
     {
         let hash = self.hash_usize(&key);
 
@@ -943,8 +931,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
 
     fn _remove_if<Q>(&self, key: &Q, f: impl FnOnce(&K, &V) -> bool) -> Option<(K, V)>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Hash + Equivalent<K> + ?Sized,
     {
         let hash = self.hash_usize(&key);
 
@@ -970,8 +957,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
 
     fn _remove_if_mut<Q>(&self, key: &Q, f: impl FnOnce(&K, &mut V) -> bool) -> Option<(K, V)>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Hash + Equivalent<K> + ?Sized,
     {
         let hash = self.hash_usize(&key);
 
@@ -1005,8 +991,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
 
     fn _get<Q>(&'a self, key: &Q) -> Option<Ref<'a, K, V, S>>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Hash + Equivalent<K> + ?Sized,
     {
         let hash = self.hash_usize(&key);
 
@@ -1027,8 +1012,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
 
     fn _get_mut<Q>(&'a self, key: &Q) -> Option<RefMut<'a, K, V, S>>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Hash + Equivalent<K> + ?Sized,
     {
         let hash = self.hash_usize(&key);
 
@@ -1049,8 +1033,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
 
     fn _try_get<Q>(&'a self, key: &Q) -> TryResult<Ref<'a, K, V, S>>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Hash + Equivalent<K> + ?Sized,
     {
         let hash = self.hash_usize(&key);
 
@@ -1074,8 +1057,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
 
     fn _try_get_mut<Q>(&'a self, key: &Q) -> TryResult<RefMut<'a, K, V, S>>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Hash + Equivalent<K> + ?Sized,
     {
         let hash = self.hash_usize(&key);
 
@@ -1117,8 +1099,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
 
     fn _alter<Q>(&self, key: &Q, f: impl FnOnce(&K, V) -> V)
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Hash + Equivalent<K> + ?Sized,
     {
         if let Some(mut r) = self.get_mut(key) {
             util::map_in_place_2(r.pair_mut(), f);
@@ -1135,8 +1116,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
 
     fn _view<Q, R>(&self, key: &Q, f: impl FnOnce(&K, &V) -> R) -> Option<R>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Hash + Equivalent<K> + ?Sized,
     {
         self.get(key).map(|r| {
             let (k, v) = r.pair();
@@ -1219,8 +1199,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> Shl<(K, V)> for &'a D
 
 impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone, Q> Shr<&Q> for &'a DashMap<K, V, S>
 where
-    K: Borrow<Q>,
-    Q: Hash + Eq + ?Sized,
+    Q: Hash + Equivalent<K> + ?Sized,
 {
     type Output = Ref<'a, K, V, S>;
 
@@ -1231,8 +1210,7 @@ where
 
 impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone, Q> BitOr<&Q> for &'a DashMap<K, V, S>
 where
-    K: Borrow<Q>,
-    Q: Hash + Eq + ?Sized,
+    Q: Hash + Equivalent<K> + ?Sized,
 {
     type Output = RefMut<'a, K, V, S>;
 
@@ -1243,8 +1221,7 @@ where
 
 impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone, Q> Sub<&Q> for &'a DashMap<K, V, S>
 where
-    K: Borrow<Q>,
-    Q: Hash + Eq + ?Sized,
+    Q: Hash + Equivalent<K> + ?Sized,
 {
     type Output = Option<(K, V)>;
 
@@ -1255,8 +1232,7 @@ where
 
 impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone, Q> BitAnd<&Q> for &'a DashMap<K, V, S>
 where
-    K: Borrow<Q>,
-    Q: Hash + Eq + ?Sized,
+    Q: Hash + Equivalent<K> + ?Sized,
 {
     type Output = bool;
 

--- a/src/read_only.rs
+++ b/src/read_only.rs
@@ -2,9 +2,9 @@ use crate::lock::RwLock;
 use crate::t::Map;
 use crate::{DashMap, HashMap};
 use cfg_if::cfg_if;
-use core::borrow::Borrow;
 use core::fmt;
 use core::hash::{BuildHasher, Hash};
+use hashbrown::Equivalent;
 use std::collections::hash_map::RandomState;
 
 /// A read-only view into a `DashMap`. Allows to obtain raw references to the stored values.
@@ -58,8 +58,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> ReadOnlyView<K, V, S>
     /// Returns `true` if the map contains a value for the specified key.
     pub fn contains_key<Q>(&'a self, key: &Q) -> bool
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Hash + Equivalent<K> + ?Sized,
     {
         let hash = self.map.hash_usize(&key);
 
@@ -73,8 +72,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> ReadOnlyView<K, V, S>
     /// Returns a reference to the value corresponding to the key.
     pub fn get<Q>(&'a self, key: &Q) -> Option<&'a V>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Hash + Equivalent<K> + ?Sized,
     {
         let hash = self.map.hash_usize(&key);
 
@@ -88,8 +86,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> ReadOnlyView<K, V, S>
     /// Returns the key-value pair corresponding to the supplied key.
     pub fn get_key_value<Q>(&'a self, key: &Q) -> Option<(&'a K, &'a V)>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Hash + Equivalent<K> + ?Sized,
     {
         let hash = self.map.hash_usize(&key);
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -6,10 +6,10 @@ use crate::DashMap;
 #[cfg(feature = "raw-api")]
 use crate::HashMap;
 use cfg_if::cfg_if;
-use core::borrow::Borrow;
 use core::fmt;
 use core::hash::{BuildHasher, Hash};
 use core::iter::FromIterator;
+use hashbrown::Equivalent;
 use std::collections::hash_map::RandomState;
 
 /// DashSet is a thin wrapper around [`DashMap`] using `()` as the value type. It uses
@@ -161,8 +161,7 @@ impl<'a, K: 'a + Eq + Hash, S: BuildHasher + Clone> DashSet<K, S> {
             /// ```
             pub fn determine_map<Q>(&self, key: &Q) -> usize
             where
-                K: Borrow<Q>,
-                Q: Hash + Eq + ?Sized,
+                Q: Hash + Equivalent<K> + ?Sized,
             {
                 self.inner.determine_map(key)
             }
@@ -218,8 +217,7 @@ impl<'a, K: 'a + Eq + Hash, S: BuildHasher + Clone> DashSet<K, S> {
     /// ```
     pub fn remove<Q>(&self, key: &Q) -> Option<K>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Hash + Equivalent<K> + ?Sized,
     {
         self.inner.remove(key).map(|(k, _)| k)
     }
@@ -245,8 +243,7 @@ impl<'a, K: 'a + Eq + Hash, S: BuildHasher + Clone> DashSet<K, S> {
     /// ```
     pub fn remove_if<Q>(&self, key: &Q, f: impl FnOnce(&K) -> bool) -> Option<K>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Hash + Equivalent<K> + ?Sized,
     {
         // TODO: Don't create another closure around f
         self.inner.remove_if(key, |k, _| f(k)).map(|(k, _)| k)
@@ -282,8 +279,7 @@ impl<'a, K: 'a + Eq + Hash, S: BuildHasher + Clone> DashSet<K, S> {
     /// ```
     pub fn get<Q>(&'a self, key: &Q) -> Option<Ref<'a, K, S>>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Hash + Equivalent<K> + ?Sized,
     {
         self.inner.get(key).map(Ref::new)
     }
@@ -378,8 +374,7 @@ impl<'a, K: 'a + Eq + Hash, S: BuildHasher + Clone> DashSet<K, S> {
     /// ```
     pub fn contains<Q>(&self, key: &Q) -> bool
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Hash + Equivalent<K> + ?Sized,
     {
         self.inner.contains_key(key)
     }

--- a/src/t.rs
+++ b/src/t.rs
@@ -1,12 +1,13 @@
 //! Central map trait to ease modifications and extensions down the road.
 
+use hashbrown::Equivalent;
+
 use crate::iter::{Iter, IterMut};
 use crate::lock::{RwLockReadGuard, RwLockWriteGuard};
 use crate::mapref::entry::Entry;
 use crate::mapref::one::{Ref, RefMut};
 use crate::try_result::TryResult;
 use crate::HashMap;
-use core::borrow::Borrow;
 use core::hash::{BuildHasher, Hash};
 
 /// Implementation detail that is exposed due to generic constraints in public types.
@@ -48,18 +49,15 @@ pub trait Map<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + Clone + BuildHasher> {
 
     fn _remove<Q>(&self, key: &Q) -> Option<(K, V)>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized;
+        Q: Hash + Equivalent<K> + ?Sized;
 
     fn _remove_if<Q>(&self, key: &Q, f: impl FnOnce(&K, &V) -> bool) -> Option<(K, V)>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized;
+        Q: Hash + Equivalent<K> + ?Sized;
 
     fn _remove_if_mut<Q>(&self, key: &Q, f: impl FnOnce(&K, &mut V) -> bool) -> Option<(K, V)>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized;
+        Q: Hash + Equivalent<K> + ?Sized;
 
     fn _iter(&'a self) -> Iter<'a, K, V, S, Self>
     where
@@ -71,23 +69,19 @@ pub trait Map<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + Clone + BuildHasher> {
 
     fn _get<Q>(&'a self, key: &Q) -> Option<Ref<'a, K, V, S>>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized;
+        Q: Hash + Equivalent<K> + ?Sized;
 
     fn _get_mut<Q>(&'a self, key: &Q) -> Option<RefMut<'a, K, V, S>>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized;
+        Q: Hash + Equivalent<K> + ?Sized;
 
     fn _try_get<Q>(&'a self, key: &Q) -> TryResult<Ref<'a, K, V, S>>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized;
+        Q: Hash + Equivalent<K> + ?Sized;
 
     fn _try_get_mut<Q>(&'a self, key: &Q) -> TryResult<RefMut<'a, K, V, S>>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized;
+        Q: Hash + Equivalent<K> + ?Sized;
 
     fn _shrink_to_fit(&self);
 
@@ -99,15 +93,13 @@ pub trait Map<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + Clone + BuildHasher> {
 
     fn _alter<Q>(&self, key: &Q, f: impl FnOnce(&K, V) -> V)
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized;
+        Q: Hash + Equivalent<K> + ?Sized;
 
     fn _alter_all(&self, f: impl FnMut(&K, V) -> V);
 
     fn _view<Q, R>(&self, key: &Q, f: impl FnOnce(&K, &V) -> R) -> Option<R>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized;
+        Q: Hash + Equivalent<K> + ?Sized;
 
     fn _entry(&'a self, key: K) -> Entry<'a, K, V, S>;
 
@@ -122,8 +114,7 @@ pub trait Map<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + Clone + BuildHasher> {
 
     fn _contains_key<Q>(&'a self, key: &Q) -> bool
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Hash + Equivalent<K> + ?Sized,
     {
         self._get(key).is_some()
     }


### PR DESCRIPTION
Equivalent trait is implemented automatically for Borrow, but additionally it can be implemented for complex types. 

Also reexports hashbrown::Equivalent to ease custom implementations without having to add hashbrown crate to dependencies.