### PR TITLE
Cloning iterators

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -118,9 +118,13 @@ pub struct Iter<'a, K, V, S = RandomState, M = DashMap<K, V, S>> {
     current: Option<GuardIter<'a, K, V, S>>,
 }
 
-impl<'i, K: Clone + Hash + Eq, V: Clone, S: Clone + BuildHasher> Clone for Iter<'i, K, V, S> {
+impl<'i, K, V, S, M> Clone for Iter<'i, K, V, S, M> {
     fn clone(&self) -> Self {
-        Iter::new(self.map)
+        Iter {
+            map: self.map,
+            shard_i: self.shard_i,
+            current: self.current.clone(),
+        }
     }
 }
 

--- a/src/iter_set.rs
+++ b/src/iter_set.rs
@@ -1,5 +1,6 @@
 use crate::setref::multiple::RefMulti;
 use crate::t::Map;
+use crate::DashMap;
 use core::hash::{BuildHasher, Hash};
 
 pub struct OwningIter<K, S> {
@@ -34,8 +35,16 @@ where
 {
 }
 
-pub struct Iter<'a, K, S, M> {
+pub struct Iter<'a, K, S, M = DashMap<K, (), S>> {
     inner: crate::iter::Iter<'a, K, (), S, M>,
+}
+
+impl<'i, K, S, M> Clone for Iter<'i, K, S, M> {
+    fn clone(&self) -> Self {
+        Iter {
+            inner: Clone::clone(&self.inner),
+        }
+    }
 }
 
 unsafe impl<'a, 'i, K, S, M> Send for Iter<'i, K, S, M>


### PR DESCRIPTION
This makes it possible to clone iterators even when the keys and values of a map are not cloneable, since they aren't being cloned.

It also makes a small change to `IterSet` to default the map argument, like `Iter` does.