### PR TITLE
Replace internal hashtable with hashbrown RawTable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,9 +91,9 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 
 [[package]]
 name = "hermit-abi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ inline = ["hashbrown/inline-more"]
 [dependencies]
 lock_api = "0.4.10"
 parking_lot_core = "0.9.8"
-hashbrown = { version = "0.14.0", default-features = false }
+hashbrown = { version = "0.14.0", default-features = false, features = ["raw"] }
 serde = { version = "1.0.188", optional = true, features = ["derive"] }
 cfg-if = "1.0.0"
 rayon = { version = "1.7.0", optional = true }

--- a/src/iter_set.rs
+++ b/src/iter_set.rs
@@ -63,7 +63,7 @@ impl<'a, K: Eq + Hash, S: 'a + BuildHasher + Clone, M: Map<'a, K, (), S>> Iter<'
 impl<'a, K: Eq + Hash, S: 'a + BuildHasher + Clone, M: Map<'a, K, (), S>> Iterator
     for Iter<'a, K, S, M>
 {
-    type Item = RefMulti<'a, K, S>;
+    type Item = RefMulti<'a, K>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next().map(RefMulti::new)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ cfg_if! {
     }
 }
 
-pub(crate) type HashMap<K, V, S> = hashbrown::HashMap<K, SharedValue<V>, S>;
+pub(crate) type HashMap<K, V> = hashbrown::raw::RawTable<(K, SharedValue<V>)>;
 
 // Temporary reimplementation of [`std::collections::TryReserveError`]
 // util [`std::collections::TryReserveError`] stabilises.
@@ -79,7 +79,7 @@ fn ncb(shard_amount: usize) -> usize {
 /// DashMap tries to implement an easy to use API similar to `std::collections::HashMap`
 /// with some slight changes to handle concurrency.
 ///
-/// DashMap tries to be very simple to use and to be a direct replacement for `RwLock<HashMap<K, V, S>>`.
+/// DashMap tries to be very simple to use and to be a direct replacement for `RwLock<HashMap<K, V>>`.
 /// To accomplish this, all methods take `&self` instead of modifying methods taking `&mut self`.
 /// This allows you to put a DashMap in an `Arc<T>` and share it between threads while being able to modify it.
 ///
@@ -87,7 +87,7 @@ fn ncb(shard_amount: usize) -> usize {
 /// This means that it is safe to ignore it across multiple threads.
 pub struct DashMap<K, V, S = RandomState> {
     shift: usize,
-    shards: Box<[RwLock<HashMap<K, V, S>>]>,
+    shards: Box<[RwLock<HashMap<K, V>>]>,
     hasher: S,
 }
 
@@ -282,7 +282,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
         let cps = capacity / shard_amount;
 
         let shards = (0..shard_amount)
-            .map(|_| RwLock::new(HashMap::with_capacity_and_hasher(cps, hasher.clone())))
+            .map(|_| RwLock::new(HashMap::with_capacity(cps)))
             .collect();
 
         Self {
@@ -295,11 +295,15 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     /// Hash a given item to produce a usize.
     /// Uses the provided or default HashBuilder.
     pub fn hash_usize<T: Hash>(&self, item: &T) -> usize {
+        self.hash_u64(item) as usize
+    }
+
+    fn hash_u64<T: Hash>(&self, item: &T) -> u64 {
         let mut hasher = self.hasher.build_hasher();
 
         item.hash(&mut hasher);
 
-        hasher.finish() as usize
+        hasher.finish()
     }
 
     cfg_if! {
@@ -317,7 +321,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
             /// let map = DashMap::<(), ()>::new();
             /// println!("Amount of shards: {}", map.shards().len());
             /// ```
-            pub fn shards(&self) -> &[RwLock<HashMap<K, V, S>>] {
+            pub fn shards(&self) -> &[RwLock<HashMap<K, V>>] {
                 &self.shards
             }
 
@@ -337,7 +341,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
             /// map.shards_mut()[shard_ind].get_mut().insert(42, SharedValue::new("forty two"));
             /// assert_eq!(*map.get(&42).unwrap(), "forty two");
             /// ```
-            pub fn shards_mut(&mut self) -> &mut [RwLock<HashMap<K, V, S>>] {
+            pub fn shards_mut(&mut self) -> &mut [RwLock<HashMap<K, V>>] {
                 &mut self.shards
             }
 
@@ -347,22 +351,22 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
             /// Requires the `raw-api` feature to be enabled.
             ///
             /// See [`DashMap::shards()`] and [`DashMap::shards_mut()`] for more information.
-            pub fn into_shards(self) -> Box<[RwLock<HashMap<K, V, S>>]> {
+            pub fn into_shards(self) -> Box<[RwLock<HashMap<K, V>>]> {
                 self.shards
             }
         } else {
             #[allow(dead_code)]
-            pub(crate) fn shards(&self) -> &[RwLock<HashMap<K, V, S>>] {
+            pub(crate) fn shards(&self) -> &[RwLock<HashMap<K, V>>] {
                 &self.shards
             }
 
             #[allow(dead_code)]
-            pub(crate) fn shards_mut(&mut self) -> &mut [RwLock<HashMap<K, V, S>>] {
+            pub(crate) fn shards_mut(&mut self) -> &mut [RwLock<HashMap<K, V>>] {
                 &mut self.shards
             }
 
             #[allow(dead_code)]
-            pub(crate) fn into_shards(self) -> Box<[RwLock<HashMap<K, V, S>>]> {
+            pub(crate) fn into_shards(self) -> Box<[RwLock<HashMap<K, V>>]> {
                 self.shards
             }
         }
@@ -565,7 +569,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     /// youtubers.insert("Bosnian Bill", 457000);
     /// assert_eq!(*youtubers.get("Bosnian Bill").unwrap(), 457000);
     /// ```
-    pub fn get<Q>(&'a self, key: &Q) -> Option<Ref<'a, K, V, S>>
+    pub fn get<Q>(&'a self, key: &Q) -> Option<Ref<'a, K, V>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
@@ -587,7 +591,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     /// *class.get_mut("Albin").unwrap() -= 1;
     /// assert_eq!(*class.get("Albin").unwrap(), 14);
     /// ```
-    pub fn get_mut<Q>(&'a self, key: &Q) -> Option<RefMut<'a, K, V, S>>
+    pub fn get_mut<Q>(&'a self, key: &Q) -> Option<RefMut<'a, K, V>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
@@ -614,7 +618,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     /// let result2 = map.try_get("Johnny");
     /// assert!(result2.is_locked());
     /// ```
-    pub fn try_get<Q>(&'a self, key: &Q) -> TryResult<Ref<'a, K, V, S>>
+    pub fn try_get<Q>(&'a self, key: &Q) -> TryResult<Ref<'a, K, V>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
@@ -642,7 +646,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     /// let result2 = map.try_get_mut("Johnny");
     /// assert!(result2.is_locked());
     /// ```
-    pub fn try_get_mut<Q>(&'a self, key: &Q) -> TryResult<RefMut<'a, K, V, S>>
+    pub fn try_get_mut<Q>(&'a self, key: &Q) -> TryResult<RefMut<'a, K, V>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
@@ -841,7 +845,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     /// See the documentation on `dashmap::mapref::entry` for more details.
     ///
     /// **Locking behaviour:** May deadlock if called when holding any sort of reference into the map.
-    pub fn entry(&'a self, key: K) -> Entry<'a, K, V, S> {
+    pub fn entry(&'a self, key: K) -> Entry<'a, K, V> {
         self._entry(key)
     }
 
@@ -849,7 +853,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     /// See the documentation on `dashmap::mapref::entry` for more details.
     ///
     /// Returns None if the shard is currently locked.
-    pub fn try_entry(&'a self, key: K) -> Option<Entry<'a, K, V, S>> {
+    pub fn try_entry(&'a self, key: K) -> Option<Entry<'a, K, V>> {
         self._try_entry(key)
     }
 
@@ -865,7 +869,11 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
         for shard in self.shards.iter() {
             shard
                 .write()
-                .try_reserve(additional)
+                .try_reserve(additional, |(k, _v)| {
+                    let mut hasher = self.hasher.build_hasher();
+                    k.hash(&mut hasher);
+                    hasher.finish()
+                })
                 .map_err(|_| TryReserveError {})?;
         }
         Ok(())
@@ -879,19 +887,19 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
         self.shards.len()
     }
 
-    unsafe fn _get_read_shard(&'a self, i: usize) -> &'a HashMap<K, V, S> {
+    unsafe fn _get_read_shard(&'a self, i: usize) -> &'a HashMap<K, V> {
         debug_assert!(i < self.shards.len());
 
         &*self.shards.get_unchecked(i).data_ptr()
     }
 
-    unsafe fn _yield_read_shard(&'a self, i: usize) -> RwLockReadGuard<'a, HashMap<K, V, S>> {
+    unsafe fn _yield_read_shard(&'a self, i: usize) -> RwLockReadGuard<'a, HashMap<K, V>> {
         debug_assert!(i < self.shards.len());
 
         self.shards.get_unchecked(i).read()
     }
 
-    unsafe fn _yield_write_shard(&'a self, i: usize) -> RwLockWriteGuard<'a, HashMap<K, V, S>> {
+    unsafe fn _yield_write_shard(&'a self, i: usize) -> RwLockWriteGuard<'a, HashMap<K, V>> {
         debug_assert!(i < self.shards.len());
 
         self.shards.get_unchecked(i).write()
@@ -900,7 +908,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
     unsafe fn _try_yield_read_shard(
         &'a self,
         i: usize,
-    ) -> Option<RwLockReadGuard<'a, HashMap<K, V, S>>> {
+    ) -> Option<RwLockReadGuard<'a, HashMap<K, V>>> {
         debug_assert!(i < self.shards.len());
 
         self.shards.get_unchecked(i).try_read()
@@ -909,22 +917,20 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
     unsafe fn _try_yield_write_shard(
         &'a self,
         i: usize,
-    ) -> Option<RwLockWriteGuard<'a, HashMap<K, V, S>>> {
+    ) -> Option<RwLockWriteGuard<'a, HashMap<K, V>>> {
         debug_assert!(i < self.shards.len());
 
         self.shards.get_unchecked(i).try_write()
     }
 
     fn _insert(&self, key: K, value: V) -> Option<V> {
-        let hash = self.hash_usize(&key);
-
-        let idx = self.determine_shard(hash);
-
-        let mut shard = unsafe { self._yield_write_shard(idx) };
-
-        shard
-            .insert(key, SharedValue::new(value))
-            .map(|v| v.into_inner())
+        match self.entry(key) {
+            Entry::Occupied(mut o) => Some(o.insert(value)),
+            Entry::Vacant(v) => {
+                v.insert(value);
+                None
+            }
+        }
     }
 
     fn _remove<Q>(&self, key: &Q) -> Option<(K, V)>
@@ -932,13 +938,18 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        let hash = self.hash_usize(&key);
+        let hash = self.hash_u64(&key);
 
-        let idx = self.determine_shard(hash);
+        let idx = self.determine_shard(hash as usize);
 
         let mut shard = unsafe { self._yield_write_shard(idx) };
 
-        shard.remove_entry(key).map(|(k, v)| (k, v.into_inner()))
+        if let Some(bucket) = shard.find(hash, |(k, _v)| key == k.borrow()) {
+            let ((k, v), _) = unsafe { shard.remove(bucket) };
+            Some((k, v.into_inner()))
+        } else {
+            None
+        }
     }
 
     fn _remove_if<Q>(&self, key: &Q, f: impl FnOnce(&K, &V) -> bool) -> Option<(K, V)>
@@ -946,22 +957,19 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        let hash = self.hash_usize(&key);
+        let hash = self.hash_u64(&key);
 
-        let idx = self.determine_shard(hash);
+        let idx = self.determine_shard(hash as usize);
 
         let mut shard = unsafe { self._yield_write_shard(idx) };
 
-        if let Some((kptr, vptr)) = shard.get_key_value(key) {
-            unsafe {
-                let kptr: *const K = kptr;
-                let vptr: *mut V = vptr.as_ptr();
-
-                if f(&*kptr, &mut *vptr) {
-                    shard.remove_entry(key).map(|(k, v)| (k, v.into_inner()))
-                } else {
-                    None
-                }
+        if let Some(bucket) = shard.find(hash, |(k, _v)| key == k.borrow()) {
+            let (k, v) = unsafe { bucket.as_ref() };
+            if f(k, v.get()) {
+                let ((k, v), _) = unsafe { shard.remove(bucket) };
+                Some((k, v.into_inner()))
+            } else {
+                None
             }
         } else {
             None
@@ -973,22 +981,19 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        let hash = self.hash_usize(&key);
+        let hash = self.hash_u64(&key);
 
-        let idx = self.determine_shard(hash);
+        let idx = self.determine_shard(hash as usize);
 
         let mut shard = unsafe { self._yield_write_shard(idx) };
 
-        if let Some((kptr, vptr)) = shard.get_key_value(key) {
-            unsafe {
-                let kptr: *const K = kptr;
-                let vptr: *mut V = vptr.as_ptr();
-
-                if f(&*kptr, &mut *vptr) {
-                    shard.remove_entry(key).map(|(k, v)| (k, v.into_inner()))
-                } else {
-                    None
-                }
+        if let Some(bucket) = shard.find(hash, |(k, _v)| key == k.borrow()) {
+            let (k, v) = unsafe { bucket.as_mut() };
+            if f(k, v.get_mut()) {
+                let ((k, v), _) = unsafe { shard.remove(bucket) };
+                Some((k, v.into_inner()))
+            } else {
+                None
             }
         } else {
             None
@@ -1003,94 +1008,90 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
         IterMut::new(self)
     }
 
-    fn _get<Q>(&'a self, key: &Q) -> Option<Ref<'a, K, V, S>>
+    fn _get<Q>(&'a self, key: &Q) -> Option<Ref<'a, K, V>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        let hash = self.hash_usize(&key);
+        let hash = self.hash_u64(&key);
 
-        let idx = self.determine_shard(hash);
+        let idx = self.determine_shard(hash as usize);
 
         let shard = unsafe { self._yield_read_shard(idx) };
 
-        if let Some((kptr, vptr)) = shard.get_key_value(key) {
+        if let Some(bucket) = shard.find(hash, |(k, _v)| key == k.borrow()) {
             unsafe {
-                let kptr: *const K = kptr;
-                let vptr: *const V = vptr.get();
-                Some(Ref::new(shard, kptr, vptr))
+                let (k, v) = bucket.as_ref();
+                Some(Ref::new(shard, k, v.as_ptr()))
             }
         } else {
             None
         }
     }
 
-    fn _get_mut<Q>(&'a self, key: &Q) -> Option<RefMut<'a, K, V, S>>
+    fn _get_mut<Q>(&'a self, key: &Q) -> Option<RefMut<'a, K, V>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        let hash = self.hash_usize(&key);
+        let hash = self.hash_u64(&key);
 
-        let idx = self.determine_shard(hash);
+        let idx = self.determine_shard(hash as usize);
 
         let shard = unsafe { self._yield_write_shard(idx) };
 
-        if let Some((kptr, vptr)) = shard.get_key_value(key) {
+        if let Some(bucket) = shard.find(hash, |(k, _v)| key == k.borrow()) {
             unsafe {
-                let kptr: *const K = kptr;
-                let vptr: *mut V = vptr.as_ptr();
-                Some(RefMut::new(shard, kptr, vptr))
+                let (k, v) = bucket.as_ref();
+                Some(RefMut::new(shard, k, v.as_ptr()))
             }
         } else {
             None
         }
     }
 
-    fn _try_get<Q>(&'a self, key: &Q) -> TryResult<Ref<'a, K, V, S>>
+    fn _try_get<Q>(&'a self, key: &Q) -> TryResult<Ref<'a, K, V>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        let hash = self.hash_usize(&key);
+        let hash = self.hash_u64(&key);
 
-        let idx = self.determine_shard(hash);
+        let idx = self.determine_shard(hash as usize);
 
         let shard = match unsafe { self._try_yield_read_shard(idx) } {
             Some(shard) => shard,
             None => return TryResult::Locked,
         };
 
-        if let Some((kptr, vptr)) = shard.get_key_value(key) {
+        if let Some(bucket) = shard.find(hash, |(k, _v)| key == k.borrow()) {
             unsafe {
-                let kptr: *const K = kptr;
-                let vptr: *const V = vptr.get();
-                TryResult::Present(Ref::new(shard, kptr, vptr))
+                let (k, v) = bucket.as_ref();
+                TryResult::Present(Ref::new(shard, k, v.as_ptr()))
             }
         } else {
             TryResult::Absent
         }
     }
 
-    fn _try_get_mut<Q>(&'a self, key: &Q) -> TryResult<RefMut<'a, K, V, S>>
+    fn _try_get_mut<Q>(&'a self, key: &Q) -> TryResult<RefMut<'a, K, V>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        let hash = self.hash_usize(&key);
+        let hash = self.hash_u64(&key);
 
-        let idx = self.determine_shard(hash);
+        let idx = self.determine_shard(hash as usize);
 
         let shard = match unsafe { self._try_yield_write_shard(idx) } {
             Some(shard) => shard,
             None => return TryResult::Locked,
         };
 
-        if let Some((kptr, vptr)) = shard.get_key_value(key) {
+        if let Some(bucket) = shard.find(hash, |(k, _v)| key == k.borrow()) {
             unsafe {
-                let kptr: *const K = kptr;
-                let vptr: *mut V = vptr.as_ptr();
-                TryResult::Present(RefMut::new(shard, kptr, vptr))
+                let (k, v) = bucket.as_ref();
+                TryResult::Present(RefMut::new(shard, k, v.as_ptr()))
             }
         } else {
             TryResult::Absent
@@ -1098,13 +1099,28 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
     }
 
     fn _shrink_to_fit(&self) {
-        self.shards.iter().for_each(|s| s.write().shrink_to_fit());
+        self.shards.iter().for_each(|s| {
+            s.write().shrink_to(self.len(), |(k, _v)| {
+                let mut hasher = self.hasher.build_hasher();
+                k.hash(&mut hasher);
+                hasher.finish()
+            })
+        });
     }
 
     fn _retain(&self, mut f: impl FnMut(&K, &mut V) -> bool) {
-        self.shards
-            .iter()
-            .for_each(|s| s.write().retain(|k, v| f(k, v.get_mut())));
+        self.shards.iter().for_each(|s| {
+            unsafe {
+                let mut shard = s.write();
+                // Here we only use `iter` as a temporary, preventing use-after-free
+                for bucket in shard.iter() {
+                    let (k, v) = bucket.as_mut();
+                    if !f(&*k, v.get_mut()) {
+                        shard.erase(bucket);
+                    }
+                }
+            }
+        });
     }
 
     fn _len(&self) -> usize {
@@ -1126,11 +1142,8 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
     }
 
     fn _alter_all(&self, mut f: impl FnMut(&K, V) -> V) {
-        self.shards.iter().for_each(|s| {
-            s.write()
-                .iter_mut()
-                .for_each(|(k, v)| util::map_in_place_2((k, v.get_mut()), &mut f));
-        });
+        self.iter_mut()
+            .for_each(|mut m| util::map_in_place_2(m.pair_mut(), &mut f));
     }
 
     fn _view<Q, R>(&self, key: &Q, f: impl FnOnce(&K, &V) -> R) -> Option<R>
@@ -1144,47 +1157,52 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
         })
     }
 
-    fn _entry(&'a self, key: K) -> Entry<'a, K, V, S> {
-        let hash = self.hash_usize(&key);
+    fn _entry(&'a self, key: K) -> Entry<'a, K, V> {
+        let hash = self.hash_u64(&key);
 
-        let idx = self.determine_shard(hash);
+        let idx = self.determine_shard(hash as usize);
 
-        let shard = unsafe { self._yield_write_shard(idx) };
+        let mut shard = unsafe { self._yield_write_shard(idx) };
 
-        if let Some((kptr, vptr)) = shard.get_key_value(&key) {
-            unsafe {
-                let kptr: *const K = kptr;
-                let vptr: *mut V = vptr.as_ptr();
-                Entry::Occupied(OccupiedEntry::new(shard, key, (kptr, vptr)))
-            }
-        } else {
-            unsafe { Entry::Vacant(VacantEntry::new(shard, key)) }
+        match shard.find_or_find_insert_slot(
+            hash,
+            |(k, _v)| k == &key,
+            |(k, _v)| {
+                let mut hasher = self.hasher.build_hasher();
+                k.hash(&mut hasher);
+                hasher.finish()
+            },
+        ) {
+            Ok(elem) => Entry::Occupied(unsafe { OccupiedEntry::new(shard, key, elem) }),
+            Err(slot) => Entry::Vacant(unsafe { VacantEntry::new(shard, key, hash, slot) }),
         }
     }
 
-    fn _try_entry(&'a self, key: K) -> Option<Entry<'a, K, V, S>> {
-        let hash = self.hash_usize(&key);
+    fn _try_entry(&'a self, key: K) -> Option<Entry<'a, K, V>> {
+        let hash = self.hash_u64(&key);
 
-        let idx = self.determine_shard(hash);
+        let idx = self.determine_shard(hash as usize);
 
-        let shard = match unsafe { self._try_yield_write_shard(idx) } {
+        let mut shard = match unsafe { self._try_yield_write_shard(idx) } {
             Some(shard) => shard,
             None => return None,
         };
 
-        if let Some((kptr, vptr)) = shard.get_key_value(&key) {
-            unsafe {
-                let kptr: *const K = kptr;
-                let vptr: *mut V = vptr.as_ptr();
-
-                Some(Entry::Occupied(OccupiedEntry::new(
-                    shard,
-                    key,
-                    (kptr, vptr),
-                )))
-            }
-        } else {
-            unsafe { Some(Entry::Vacant(VacantEntry::new(shard, key))) }
+        match shard.find_or_find_insert_slot(
+            hash,
+            |(k, _v)| k == &key,
+            |(k, _v)| {
+                let mut hasher = self.hasher.build_hasher();
+                k.hash(&mut hasher);
+                hasher.finish()
+            },
+        ) {
+            Ok(elem) => Some(Entry::Occupied(unsafe {
+                OccupiedEntry::new(shard, key, elem)
+            })),
+            Err(slot) => Some(Entry::Vacant(unsafe {
+                VacantEntry::new(shard, key, hash, slot)
+            })),
         }
     }
 
@@ -1222,7 +1240,7 @@ where
     K: Borrow<Q>,
     Q: Hash + Eq + ?Sized,
 {
-    type Output = Ref<'a, K, V, S>;
+    type Output = Ref<'a, K, V>;
 
     fn shr(self, key: &Q) -> Self::Output {
         self.get(key).unwrap()
@@ -1234,7 +1252,7 @@ where
     K: Borrow<Q>,
     Q: Hash + Eq + ?Sized,
 {
-    type Output = RefMut<'a, K, V, S>;
+    type Output = RefMut<'a, K, V>;
 
     fn bitor(self, key: &Q) -> Self::Output {
         self.get_mut(key).unwrap()
@@ -1276,7 +1294,7 @@ impl<K: Eq + Hash, V, S: BuildHasher + Clone> IntoIterator for DashMap<K, V, S> 
 }
 
 impl<'a, K: Eq + Hash, V, S: BuildHasher + Clone> IntoIterator for &'a DashMap<K, V, S> {
-    type Item = RefMulti<'a, K, V, S>;
+    type Item = RefMulti<'a, K, V>;
 
     type IntoIter = Iter<'a, K, V, S, DashMap<K, V, S>>;
 

--- a/src/mapref/multiple.rs
+++ b/src/mapref/multiple.rs
@@ -1,23 +1,21 @@
 use crate::lock::{RwLockReadGuard, RwLockWriteGuard};
 use crate::HashMap;
-use core::hash::BuildHasher;
 use core::hash::Hash;
 use core::ops::{Deref, DerefMut};
-use std::collections::hash_map::RandomState;
 use std::sync::Arc;
 
-pub struct RefMulti<'a, K, V, S = RandomState> {
-    _guard: Arc<RwLockReadGuard<'a, HashMap<K, V, S>>>,
+pub struct RefMulti<'a, K, V> {
+    _guard: Arc<RwLockReadGuard<'a, HashMap<K, V>>>,
     k: *const K,
     v: *const V,
 }
 
-unsafe impl<'a, K: Eq + Hash + Sync, V: Sync, S: BuildHasher> Send for RefMulti<'a, K, V, S> {}
-unsafe impl<'a, K: Eq + Hash + Sync, V: Sync, S: BuildHasher> Sync for RefMulti<'a, K, V, S> {}
+unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Send for RefMulti<'a, K, V> {}
+unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Sync for RefMulti<'a, K, V> {}
 
-impl<'a, K: Eq + Hash, V, S: BuildHasher> RefMulti<'a, K, V, S> {
+impl<'a, K: Eq + Hash, V> RefMulti<'a, K, V> {
     pub(crate) unsafe fn new(
-        guard: Arc<RwLockReadGuard<'a, HashMap<K, V, S>>>,
+        guard: Arc<RwLockReadGuard<'a, HashMap<K, V>>>,
         k: *const K,
         v: *const V,
     ) -> Self {
@@ -41,7 +39,7 @@ impl<'a, K: Eq + Hash, V, S: BuildHasher> RefMulti<'a, K, V, S> {
     }
 }
 
-impl<'a, K: Eq + Hash, V, S: BuildHasher> Deref for RefMulti<'a, K, V, S> {
+impl<'a, K: Eq + Hash, V> Deref for RefMulti<'a, K, V> {
     type Target = V;
 
     fn deref(&self) -> &V {
@@ -49,18 +47,18 @@ impl<'a, K: Eq + Hash, V, S: BuildHasher> Deref for RefMulti<'a, K, V, S> {
     }
 }
 
-pub struct RefMutMulti<'a, K, V, S = RandomState> {
-    _guard: Arc<RwLockWriteGuard<'a, HashMap<K, V, S>>>,
+pub struct RefMutMulti<'a, K, V> {
+    _guard: Arc<RwLockWriteGuard<'a, HashMap<K, V>>>,
     k: *const K,
     v: *mut V,
 }
 
-unsafe impl<'a, K: Eq + Hash + Sync, V: Sync, S: BuildHasher> Send for RefMutMulti<'a, K, V, S> {}
-unsafe impl<'a, K: Eq + Hash + Sync, V: Sync, S: BuildHasher> Sync for RefMutMulti<'a, K, V, S> {}
+unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Send for RefMutMulti<'a, K, V> {}
+unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Sync for RefMutMulti<'a, K, V> {}
 
-impl<'a, K: Eq + Hash, V, S: BuildHasher> RefMutMulti<'a, K, V, S> {
+impl<'a, K: Eq + Hash, V> RefMutMulti<'a, K, V> {
     pub(crate) unsafe fn new(
-        guard: Arc<RwLockWriteGuard<'a, HashMap<K, V, S>>>,
+        guard: Arc<RwLockWriteGuard<'a, HashMap<K, V>>>,
         k: *const K,
         v: *mut V,
     ) -> Self {
@@ -92,7 +90,7 @@ impl<'a, K: Eq + Hash, V, S: BuildHasher> RefMutMulti<'a, K, V, S> {
     }
 }
 
-impl<'a, K: Eq + Hash, V, S: BuildHasher> Deref for RefMutMulti<'a, K, V, S> {
+impl<'a, K: Eq + Hash, V> Deref for RefMutMulti<'a, K, V> {
     type Target = V;
 
     fn deref(&self) -> &V {
@@ -100,7 +98,7 @@ impl<'a, K: Eq + Hash, V, S: BuildHasher> Deref for RefMutMulti<'a, K, V, S> {
     }
 }
 
-impl<'a, K: Eq + Hash, V, S: BuildHasher> DerefMut for RefMutMulti<'a, K, V, S> {
+impl<'a, K: Eq + Hash, V> DerefMut for RefMutMulti<'a, K, V> {
     fn deref_mut(&mut self) -> &mut V {
         self.value_mut()
     }

--- a/src/rayon/read_only.rs
+++ b/src/rayon/read_only.rs
@@ -10,7 +10,7 @@ where
     V: Send,
     S: Send + Clone + BuildHasher,
 {
-    type Iter = super::map::OwningIter<K, V, S>;
+    type Iter = super::map::OwningIter<K, V>;
     type Item = (K, V);
 
     fn into_par_iter(self) -> Self::Iter {
@@ -27,8 +27,8 @@ where
     V: Send + Sync,
     S: Send + Sync + Clone + BuildHasher,
 {
-    type Iter = Iter<'a, K, V, S>;
-    type Item = RefMulti<'a, K, V, S>;
+    type Iter = Iter<'a, K, V>;
+    type Item = RefMulti<'a, K, V>;
 
     fn into_par_iter(self) -> Self::Iter {
         Iter {

--- a/src/rayon/set.rs
+++ b/src/rayon/set.rs
@@ -3,7 +3,6 @@ use crate::DashSet;
 use core::hash::{BuildHasher, Hash};
 use rayon::iter::plumbing::UnindexedConsumer;
 use rayon::iter::{FromParallelIterator, IntoParallelIterator, ParallelExtend, ParallelIterator};
-use std::collections::hash_map::RandomState;
 
 impl<K, S> ParallelExtend<K> for DashSet<K, S>
 where
@@ -56,7 +55,7 @@ where
     K: Send + Eq + Hash,
     S: Send + Clone + BuildHasher,
 {
-    type Iter = OwningIter<K, S>;
+    type Iter = OwningIter<K>;
     type Item = K;
 
     fn into_par_iter(self) -> Self::Iter {
@@ -66,14 +65,13 @@ where
     }
 }
 
-pub struct OwningIter<K, S = RandomState> {
-    inner: super::map::OwningIter<K, (), S>,
+pub struct OwningIter<K> {
+    inner: super::map::OwningIter<K, ()>,
 }
 
-impl<K, S> ParallelIterator for OwningIter<K, S>
+impl<K> ParallelIterator for OwningIter<K>
 where
     K: Send + Eq + Hash,
-    S: Send + Clone + BuildHasher,
 {
     type Item = K;
 
@@ -91,8 +89,8 @@ where
     K: Send + Sync + Eq + Hash,
     S: Send + Sync + Clone + BuildHasher,
 {
-    type Iter = Iter<'a, K, S>;
-    type Item = RefMulti<'a, K, S>;
+    type Iter = Iter<'a, K>;
+    type Item = RefMulti<'a, K>;
 
     fn into_par_iter(self) -> Self::Iter {
         Iter {
@@ -101,16 +99,15 @@ where
     }
 }
 
-pub struct Iter<'a, K, S = RandomState> {
-    inner: super::map::Iter<'a, K, (), S>,
+pub struct Iter<'a, K> {
+    inner: super::map::Iter<'a, K, ()>,
 }
 
-impl<'a, K, S> ParallelIterator for Iter<'a, K, S>
+impl<'a, K> ParallelIterator for Iter<'a, K>
 where
     K: Send + Sync + Eq + Hash,
-    S: Send + Sync + Clone + BuildHasher,
 {
-    type Item = RefMulti<'a, K, S>;
+    type Item = RefMulti<'a, K>;
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
     where

--- a/src/read_only.rs
+++ b/src/read_only.rs
@@ -61,13 +61,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> ReadOnlyView<K, V, S>
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        let hash = self.map.hash_usize(&key);
-
-        let idx = self.map.determine_shard(hash);
-
-        let shard = unsafe { self.map._get_read_shard(idx) };
-
-        shard.contains_key(key)
+        self.get(key).is_some()
     }
 
     /// Returns a reference to the value corresponding to the key.
@@ -76,13 +70,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> ReadOnlyView<K, V, S>
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        let hash = self.map.hash_usize(&key);
-
-        let idx = self.map.determine_shard(hash);
-
-        let shard = unsafe { self.map._get_read_shard(idx) };
-
-        shard.get(key).map(|v| v.get())
+        self.get_key_value(key).map(|(_k, v)| v)
     }
 
     /// Returns the key-value pair corresponding to the supplied key.
@@ -91,37 +79,39 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> ReadOnlyView<K, V, S>
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        let hash = self.map.hash_usize(&key);
+        let hash = self.map.hash_u64(&key);
 
-        let idx = self.map.determine_shard(hash);
+        let idx = self.map.determine_shard(hash as usize);
 
         let shard = unsafe { self.map._get_read_shard(idx) };
 
-        shard.get_key_value(key).map(|(k, v)| (k, v.get()))
-    }
-
-    fn shard_read_iter(&'a self) -> impl Iterator<Item = &'a HashMap<K, V, S>> + 'a {
-        (0..self.map._shard_count())
-            .map(move |shard_i| unsafe { self.map._get_read_shard(shard_i) })
+        shard.find(hash, |(k, _v)| key == k.borrow()).map(|b| {
+            let (k, v) = unsafe { b.as_ref() };
+            (k, v.get())
+        })
     }
 
     /// An iterator visiting all key-value pairs in arbitrary order. The iterator element type is `(&'a K, &'a V)`.
     pub fn iter(&'a self) -> impl Iterator<Item = (&'a K, &'a V)> + 'a {
-        self.shard_read_iter()
-            .flat_map(|shard| shard.iter())
-            .map(|(k, v)| (k, v.get()))
+        unsafe {
+            (0..self.map._shard_count())
+                .map(move |shard_i| self.map._get_read_shard(shard_i))
+                .flat_map(|shard| shard.iter())
+                .map(|b| {
+                    let (k, v) = b.as_ref();
+                    (k, v.get())
+                })
+        }
     }
 
     /// An iterator visiting all keys in arbitrary order. The iterator element type is `&'a K`.
     pub fn keys(&'a self) -> impl Iterator<Item = &'a K> + 'a {
-        self.shard_read_iter().flat_map(|shard| shard.keys())
+        self.iter().map(|(k, _v)| k)
     }
 
     /// An iterator visiting all values in arbitrary order. The iterator element type is `&'a V`.
     pub fn values(&'a self) -> impl Iterator<Item = &'a V> + 'a {
-        self.shard_read_iter()
-            .flat_map(|shard| shard.values())
-            .map(|v| v.get())
+        self.iter().map(|(_k, v)| v)
     }
 
     cfg_if! {
@@ -139,12 +129,12 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> ReadOnlyView<K, V, S>
             /// let map = DashMap::<(), ()>::new().into_read_only();
             /// println!("Amount of shards: {}", map.shards().len());
             /// ```
-            pub fn shards(&self) -> &[RwLock<HashMap<K, V, S>>] {
+            pub fn shards(&self) -> &[RwLock<HashMap<K, V>>] {
                 &self.map.shards
             }
         } else {
             #[allow(dead_code)]
-            pub(crate) fn shards(&self) -> &[RwLock<HashMap<K, V, S>>] {
+            pub(crate) fn shards(&self) -> &[RwLock<HashMap<K, V>>] {
                 &self.map.shards
             }
         }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -169,47 +169,35 @@ macro_rules! serialize_impl {
 }
 
 // Map
-impl<'a, K: Eq + Hash, V: Serialize, S: BuildHasher> Serialize
-    for mapref::multiple::RefMulti<'a, K, V, S>
-{
+impl<'a, K: Eq + Hash, V: Serialize> Serialize for mapref::multiple::RefMulti<'a, K, V> {
     serialize_impl! {}
 }
 
-impl<'a, K: Eq + Hash, V: Serialize, S: BuildHasher> Serialize
-    for mapref::multiple::RefMutMulti<'a, K, V, S>
-{
+impl<'a, K: Eq + Hash, V: Serialize> Serialize for mapref::multiple::RefMutMulti<'a, K, V> {
     serialize_impl! {}
 }
 
-impl<'a, K: Eq + Hash, V: Serialize, S: BuildHasher> Serialize for mapref::one::Ref<'a, K, V, S> {
+impl<'a, K: Eq + Hash, V: Serialize> Serialize for mapref::one::Ref<'a, K, V> {
     serialize_impl! {}
 }
 
-impl<'a, K: Eq + Hash, V: Serialize, S: BuildHasher> Serialize
-    for mapref::one::RefMut<'a, K, V, S>
-{
+impl<'a, K: Eq + Hash, V: Serialize> Serialize for mapref::one::RefMut<'a, K, V> {
     serialize_impl! {}
 }
 
-impl<'a, K: Eq + Hash, V, T: Serialize, S: BuildHasher> Serialize
-    for mapref::one::MappedRef<'a, K, V, T, S>
-{
+impl<'a, K: Eq + Hash, V, T: Serialize> Serialize for mapref::one::MappedRef<'a, K, V, T> {
     serialize_impl! {}
 }
 
-impl<'a, K: Eq + Hash, V, T: Serialize, S: BuildHasher> Serialize
-    for mapref::one::MappedRefMut<'a, K, V, T, S>
-{
+impl<'a, K: Eq + Hash, V, T: Serialize> Serialize for mapref::one::MappedRefMut<'a, K, V, T> {
     serialize_impl! {}
 }
 
 // Set
-impl<'a, V: Hash + Eq + Serialize, S: BuildHasher> Serialize
-    for setref::multiple::RefMulti<'a, V, S>
-{
+impl<'a, V: Hash + Eq + Serialize> Serialize for setref::multiple::RefMulti<'a, V> {
     serialize_impl! {}
 }
 
-impl<'a, V: Hash + Eq + Serialize, S: BuildHasher> Serialize for setref::one::Ref<'a, V, S> {
+impl<'a, V: Hash + Eq + Serialize> Serialize for setref::one::Ref<'a, V> {
     serialize_impl! {}
 }

--- a/src/set.rs
+++ b/src/set.rs
@@ -136,7 +136,7 @@ impl<'a, K: 'a + Eq + Hash, S: BuildHasher + Clone> DashSet<K, S> {
             /// let set = DashSet::<()>::new();
             /// println!("Amount of shards: {}", set.shards().len());
             /// ```
-            pub fn shards(&self) -> &[RwLock<HashMap<K, (), S>>] {
+            pub fn shards(&self) -> &[RwLock<HashMap<K, ()>>] {
                 self.inner.shards()
             }
         }
@@ -280,7 +280,7 @@ impl<'a, K: 'a + Eq + Hash, S: BuildHasher + Clone> DashSet<K, S> {
     /// youtubers.insert("Bosnian Bill");
     /// assert_eq!(*youtubers.get("Bosnian Bill").unwrap(), "Bosnian Bill");
     /// ```
-    pub fn get<Q>(&'a self, key: &Q) -> Option<Ref<'a, K, S>>
+    pub fn get<Q>(&'a self, key: &Q) -> Option<Ref<'a, K>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,

--- a/src/setref/multiple.rs
+++ b/src/setref/multiple.rs
@@ -1,13 +1,13 @@
 use crate::mapref;
-use core::hash::{BuildHasher, Hash};
+use core::hash::Hash;
 use core::ops::Deref;
-use std::collections::hash_map::RandomState;
-pub struct RefMulti<'a, K, S = RandomState> {
-    inner: mapref::multiple::RefMulti<'a, K, (), S>,
+
+pub struct RefMulti<'a, K> {
+    inner: mapref::multiple::RefMulti<'a, K, ()>,
 }
 
-impl<'a, K: Eq + Hash, S: BuildHasher> RefMulti<'a, K, S> {
-    pub(crate) fn new(inner: mapref::multiple::RefMulti<'a, K, (), S>) -> Self {
+impl<'a, K: Eq + Hash> RefMulti<'a, K> {
+    pub(crate) fn new(inner: mapref::multiple::RefMulti<'a, K, ()>) -> Self {
         Self { inner }
     }
 
@@ -16,7 +16,7 @@ impl<'a, K: Eq + Hash, S: BuildHasher> RefMulti<'a, K, S> {
     }
 }
 
-impl<'a, K: Eq + Hash, S: BuildHasher> Deref for RefMulti<'a, K, S> {
+impl<'a, K: Eq + Hash> Deref for RefMulti<'a, K> {
     type Target = K;
 
     fn deref(&self) -> &K {

--- a/src/setref/one.rs
+++ b/src/setref/one.rs
@@ -1,13 +1,13 @@
 use crate::mapref;
-use core::hash::{BuildHasher, Hash};
+use core::hash::Hash;
 use core::ops::Deref;
-use std::collections::hash_map::RandomState;
-pub struct Ref<'a, K, S = RandomState> {
-    inner: mapref::one::Ref<'a, K, (), S>,
+
+pub struct Ref<'a, K> {
+    inner: mapref::one::Ref<'a, K, ()>,
 }
 
-impl<'a, K: Eq + Hash, S: BuildHasher> Ref<'a, K, S> {
-    pub(crate) fn new(inner: mapref::one::Ref<'a, K, (), S>) -> Self {
+impl<'a, K: Eq + Hash> Ref<'a, K> {
+    pub(crate) fn new(inner: mapref::one::Ref<'a, K, ()>) -> Self {
         Self { inner }
     }
 
@@ -16,7 +16,7 @@ impl<'a, K: Eq + Hash, S: BuildHasher> Ref<'a, K, S> {
     }
 }
 
-impl<'a, K: Eq + Hash, S: BuildHasher> Deref for Ref<'a, K, S> {
+impl<'a, K: Eq + Hash> Deref for Ref<'a, K> {
     type Target = K;
 
     fn deref(&self) -> &K {

--- a/src/t.rs
+++ b/src/t.rs
@@ -16,17 +16,17 @@ pub trait Map<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + Clone + BuildHasher> {
     /// # Safety
     ///
     /// The index must not be out of bounds.
-    unsafe fn _get_read_shard(&'a self, i: usize) -> &'a HashMap<K, V, S>;
+    unsafe fn _get_read_shard(&'a self, i: usize) -> &'a HashMap<K, V>;
 
     /// # Safety
     ///
     /// The index must not be out of bounds.
-    unsafe fn _yield_read_shard(&'a self, i: usize) -> RwLockReadGuard<'a, HashMap<K, V, S>>;
+    unsafe fn _yield_read_shard(&'a self, i: usize) -> RwLockReadGuard<'a, HashMap<K, V>>;
 
     /// # Safety
     ///
     /// The index must not be out of bounds.
-    unsafe fn _yield_write_shard(&'a self, i: usize) -> RwLockWriteGuard<'a, HashMap<K, V, S>>;
+    unsafe fn _yield_write_shard(&'a self, i: usize) -> RwLockWriteGuard<'a, HashMap<K, V>>;
 
     /// # Safety
     ///
@@ -34,7 +34,7 @@ pub trait Map<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + Clone + BuildHasher> {
     unsafe fn _try_yield_read_shard(
         &'a self,
         i: usize,
-    ) -> Option<RwLockReadGuard<'a, HashMap<K, V, S>>>;
+    ) -> Option<RwLockReadGuard<'a, HashMap<K, V>>>;
 
     /// # Safety
     ///
@@ -42,7 +42,7 @@ pub trait Map<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + Clone + BuildHasher> {
     unsafe fn _try_yield_write_shard(
         &'a self,
         i: usize,
-    ) -> Option<RwLockWriteGuard<'a, HashMap<K, V, S>>>;
+    ) -> Option<RwLockWriteGuard<'a, HashMap<K, V>>>;
 
     fn _insert(&self, key: K, value: V) -> Option<V>;
 
@@ -69,22 +69,22 @@ pub trait Map<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + Clone + BuildHasher> {
     where
         Self: Sized;
 
-    fn _get<Q>(&'a self, key: &Q) -> Option<Ref<'a, K, V, S>>
+    fn _get<Q>(&'a self, key: &Q) -> Option<Ref<'a, K, V>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized;
 
-    fn _get_mut<Q>(&'a self, key: &Q) -> Option<RefMut<'a, K, V, S>>
+    fn _get_mut<Q>(&'a self, key: &Q) -> Option<RefMut<'a, K, V>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized;
 
-    fn _try_get<Q>(&'a self, key: &Q) -> TryResult<Ref<'a, K, V, S>>
+    fn _try_get<Q>(&'a self, key: &Q) -> TryResult<Ref<'a, K, V>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized;
 
-    fn _try_get_mut<Q>(&'a self, key: &Q) -> TryResult<RefMut<'a, K, V, S>>
+    fn _try_get_mut<Q>(&'a self, key: &Q) -> TryResult<RefMut<'a, K, V>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized;
@@ -109,9 +109,9 @@ pub trait Map<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + Clone + BuildHasher> {
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized;
 
-    fn _entry(&'a self, key: K) -> Entry<'a, K, V, S>;
+    fn _entry(&'a self, key: K) -> Entry<'a, K, V>;
 
-    fn _try_entry(&'a self, key: K) -> Option<Entry<'a, K, V, S>>;
+    fn _try_entry(&'a self, key: K) -> Option<Entry<'a, K, V>>;
 
     fn _hasher(&self) -> S;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,22 +18,6 @@ pub fn map_in_place_2<T, U, F: FnOnce(U, T) -> T>((k, v): (U, &mut T), f: F) {
     }
 }
 
-/// # Safety
-///
-/// Requires that you ensure the reference does not become invalid.
-/// The object has to outlive the reference.
-pub unsafe fn change_lifetime_const<'a, 'b, T>(x: &'a T) -> &'b T {
-    &*(x as *const T)
-}
-
-/// # Safety
-///
-/// Requires that you ensure the reference does not become invalid.
-/// The object has to outlive the reference.
-pub unsafe fn change_lifetime_mut<'a, 'b, T>(x: &'a mut T) -> &'b mut T {
-    &mut *(x as *mut T)
-}
-
 /// A simple wrapper around `T`
 ///
 /// This is to prevent UB when using `HashMap::get_key_value`, because


### PR DESCRIPTION
Replace internal hashtable with hashbrown RawTable.

Benefits
* Allows only hashing keys once
* Allows a more efficient implementation of the Entry api. Which will always be a single hashtable operation.
  * Previously, building the entry would lookup the hashtable once, and other operations would do another lookup (e.g. OccupiedEntry::remove or VacantEntry::insert).
* Allows dashmap raw api to be safely exposed even with the improvements above, as the shards are raw tables w/o hashers. This will avoid problems like https://github.com/xacrimon/dashmap/pull/259. crates.io use case (iterate the removed shards) will still be possible with rawtables.
* Removes a lot of generic types for the hasher
* Slightly simplifies some code paths as we don't have to fight lifetimes

The first two can be significant performance improvements in some circumstances.

Sadly, this is a breaking change for raw-api users so it'll require a major version bump.

Maybe the third time is the charm :smile: 
