### PR TITLE
Fix soundness bug and refactor away unnecessary UnsafeCell.

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -243,13 +243,9 @@ impl<'a, K: Eq + Hash, V, S: 'a + BuildHasher + Clone, M: Map<'a, K, V, S>> Iter
                 if let Some((k, v)) = current.1.next() {
                     let guard = current.0.clone();
 
-                    unsafe {
-                        let k = util::change_lifetime_const(k);
+                    let v = v.get_mut();
 
-                        let v = &mut *v.as_ptr();
-
-                        return Some(RefMutMulti::new(guard, k, v));
-                    }
+                    return Some(unsafe { RefMutMulti::new(guard, k, v) });
                 }
             }
 


### PR DESCRIPTION
- Fix a potential soundness bug by using ManuallyDrop.
- Change SharedValue to contain a T instead of a UnsafeCell<T> and remove as_ptr method.
- Swap several calls to `HashMap::get_key_value` with calls to `Hashmap::get_key_value_mut` in order to make using UnsafeCell redundant.
- Make unsafe blocks smaller and more refined.