### PR TITLE
Use FixedArray instead of Box<[T]>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,7 @@ dependencies = [
  "parking_lot_core",
  "rayon",
  "serde",
+ "small-fixed-array",
 ]
 
 [[package]]
@@ -229,6 +230,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "small-fixed-array"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2782e69a974e738ea1ef568e884347d8174a41789fe459ee73517c8acf8c9ea5"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ cfg-if = "1.0.0"
 rayon = { version = "1.7.0", optional = true }
 once_cell = "1.18.0"
 arbitrary = { version = "1.3.0", optional = true }
+small-fixed-array = "0.4.0"
 
 [package.metadata.docs.rs]
 features = ["rayon", "raw-api", "serde"]

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 /// ```
 pub struct OwningIter<K, V, S = RandomState> {
     map: DashMap<K, V, S>,
-    shard_i: usize,
+    shard_i: u32,
     current: Option<GuardOwningIter<K, V>>,
 }
 
@@ -114,7 +114,7 @@ type GuardIterMut<'a, K, V, S> = (
 /// ```
 pub struct Iter<'a, K, V, S = RandomState, M = DashMap<K, V, S>> {
     map: &'a M,
-    shard_i: usize,
+    shard_i: u32,
     current: Option<GuardIter<'a, K, V, S>>,
 }
 
@@ -198,7 +198,7 @@ impl<'a, K: Eq + Hash, V, S: 'a + BuildHasher + Clone, M: Map<'a, K, V, S>> Iter
 /// ```
 pub struct IterMut<'a, K, V, S = RandomState, M = DashMap<K, V, S>> {
     map: &'a M,
-    shard_i: usize,
+    shard_i: u32,
     current: Option<GuardIterMut<'a, K, V, S>>,
 }
 

--- a/src/rayon/map.rs
+++ b/src/rayon/map.rs
@@ -5,6 +5,7 @@ use crate::{DashMap, HashMap};
 use core::hash::{BuildHasher, Hash};
 use rayon::iter::plumbing::UnindexedConsumer;
 use rayon::iter::{FromParallelIterator, IntoParallelIterator, ParallelExtend, ParallelIterator};
+use small_fixed_array::FixedArray;
 use std::collections::hash_map::RandomState;
 use std::sync::Arc;
 
@@ -80,7 +81,7 @@ where
 }
 
 pub struct OwningIter<K, V, S = RandomState> {
-    pub(super) shards: Box<[RwLock<HashMap<K, V, S>>]>,
+    pub(super) shards: FixedArray<RwLock<HashMap<K, V, S>>>,
 }
 
 impl<K, V, S> ParallelIterator for OwningIter<K, V, S>

--- a/src/set.rs
+++ b/src/set.rs
@@ -159,7 +159,7 @@ impl<'a, K: 'a + Eq + Hash, S: BuildHasher + Clone> DashSet<K, S> {
             /// set.insert("coca-cola");
             /// println!("coca-cola is stored in shard: {}", set.determine_map("coca-cola"));
             /// ```
-            pub fn determine_map<Q>(&self, key: &Q) -> usize
+            pub fn determine_map<Q>(&self, key: &Q) -> u32
             where
                 K: Borrow<Q>,
                 Q: Hash + Eq + ?Sized,
@@ -185,7 +185,7 @@ impl<'a, K: 'a + Eq + Hash, S: BuildHasher + Clone> DashSet<K, S> {
             /// let hash = set.hash_usize(&key);
             /// println!("hash is stored in shard: {}", set.determine_shard(hash));
             /// ```
-            pub fn determine_shard(&self, hash: usize) -> usize {
+            pub fn determine_shard(&self, hash: usize) -> u32 {
                 self.inner.determine_shard(hash)
             }
         }

--- a/src/t.rs
+++ b/src/t.rs
@@ -11,29 +11,29 @@ use core::hash::{BuildHasher, Hash};
 
 /// Implementation detail that is exposed due to generic constraints in public types.
 pub trait Map<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + Clone + BuildHasher> {
-    fn _shard_count(&self) -> usize;
+    fn _shard_count(&self) -> u32;
 
     /// # Safety
     ///
     /// The index must not be out of bounds.
-    unsafe fn _get_read_shard(&'a self, i: usize) -> &'a HashMap<K, V, S>;
+    unsafe fn _get_read_shard(&'a self, i: u32) -> &'a HashMap<K, V, S>;
 
     /// # Safety
     ///
     /// The index must not be out of bounds.
-    unsafe fn _yield_read_shard(&'a self, i: usize) -> RwLockReadGuard<'a, HashMap<K, V, S>>;
+    unsafe fn _yield_read_shard(&'a self, i: u32) -> RwLockReadGuard<'a, HashMap<K, V, S>>;
 
     /// # Safety
     ///
     /// The index must not be out of bounds.
-    unsafe fn _yield_write_shard(&'a self, i: usize) -> RwLockWriteGuard<'a, HashMap<K, V, S>>;
+    unsafe fn _yield_write_shard(&'a self, i: u32) -> RwLockWriteGuard<'a, HashMap<K, V, S>>;
 
     /// # Safety
     ///
     /// The index must not be out of bounds.
     unsafe fn _try_yield_read_shard(
         &'a self,
-        i: usize,
+        i: u32,
     ) -> Option<RwLockReadGuard<'a, HashMap<K, V, S>>>;
 
     /// # Safety
@@ -41,7 +41,7 @@ pub trait Map<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + Clone + BuildHasher> {
     /// The index must not be out of bounds.
     unsafe fn _try_yield_write_shard(
         &'a self,
-        i: usize,
+        i: u32,
     ) -> Option<RwLockWriteGuard<'a, HashMap<K, V, S>>>;
 
     fn _insert(&self, key: K, value: V) -> Option<V>;

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,8 +3,8 @@
 use core::cell::UnsafeCell;
 use core::{mem, ptr};
 
-pub const fn ptr_size_bits() -> usize {
-    mem::size_of::<usize>() * 8
+pub const fn ptr_size_bits() -> u16 {
+    (mem::size_of::<usize>() * 8) as _
 }
 
 pub fn map_in_place_2<T, U, F: FnOnce(U, T) -> T>((k, v): (U, &mut T), f: F) {


### PR DESCRIPTION
This reduces the inline size of DashMap from `ptr (usize) + length (usize) + shift (usize)` to `ptr (usize) + length (u32) + shift (u16)` while removing padding which made no measurable difference in my testing. This should be benchmarked and especially checked on an ARM server to see if the padding makes a difference there.