### PR TITLE
Allow map_in_place to be called when the callee is already panicking.

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -12,9 +12,13 @@ pub fn map_in_place_2<T, U, F: FnOnce(U, T) -> T>((k, v): (U, &mut T), f: F) {
         // # Safety
         //
         // If the closure panics, we must abort otherwise we could double drop `T`
-        let _promote_panic_to_abort = AbortOnPanic;
+        let promote_panic_to_abort = AbortOnPanic;
 
         ptr::write(v, f(k, ptr::read(v)));
+
+        // If we made it here, the calling thread could have already have panicked, in which case
+        // We know that the closure did not panic, so don't bother checking.
+        std::mem::forget(promote_panic_to_abort);
     }
 }
 


### PR DESCRIPTION
- Forget the abort on panic once we know the closure did not panic.