### PR TITLE
Re-export Entry types at top level

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ use core::hash::{BuildHasher, Hash, Hasher};
 use core::iter::FromIterator;
 use core::ops::{BitAnd, BitOr, Shl, Shr, Sub};
 use iter::{Iter, IterMut, OwningIter};
-use mapref::entry::{Entry, OccupiedEntry, VacantEntry};
+pub use mapref::entry::{Entry, OccupiedEntry, VacantEntry};
 use mapref::multiple::RefMulti;
 use mapref::one::{Ref, RefMut};
 use once_cell::sync::OnceCell;


### PR DESCRIPTION
This makes it easy to `use dashmap::{DashMap, Entry}` rather than
requiring `dashmap::mapref::entry::Entry`.

This also makes it convenient to use `dashmap::Entry` as a qualified
type, in code that has other types named `Entry`.
