### PR TITLE
cache-align the shards to improve throughput

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           # --
           # install cross
           echo "installing cross"
-          cargo install cross
+          cargo install cross --locked --version 0.2.5
           # --
       - name: test
         run: cross test --target ${{ matrix.target }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,7 @@ version = "5.5.3"
 dependencies = [
  "arbitrary",
  "cfg-if",
+ "crossbeam-utils",
  "hashbrown",
  "lock_api",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ cfg-if = "1.0.0"
 rayon = { version = "1.7.0", optional = true }
 once_cell = "1.18.0"
 arbitrary = { version = "1.3.0", optional = true }
+crossbeam-utils = "0.8"
 
 [package.metadata.docs.rs]
 features = ["rayon", "raw-api", "serde"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,12 +29,12 @@ use crate::lock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 pub use crate::lock::{RawRwLock, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use cfg_if::cfg_if;
-use crossbeam_utils::CachePadded;
 use core::borrow::Borrow;
 use core::fmt;
 use core::hash::{BuildHasher, Hash, Hasher};
 use core::iter::FromIterator;
 use core::ops::{BitAnd, BitOr, Shl, Shr, Sub};
+use crossbeam_utils::CachePadded;
 use iter::{Iter, IterMut, OwningIter};
 use mapref::entry::{Entry, OccupiedEntry, VacantEntry};
 use mapref::multiple::RefMulti;
@@ -283,7 +283,12 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
         let cps = capacity / shard_amount;
 
         let shards = (0..shard_amount)
-            .map(|_| CachePadded::new(RwLock::new(HashMap::with_capacity_and_hasher(cps, hasher.clone()))))
+            .map(|_| {
+                CachePadded::new(RwLock::new(HashMap::with_capacity_and_hasher(
+                    cps,
+                    hasher.clone(),
+                )))
+            })
             .collect();
 
         Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ use crate::lock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 pub use crate::lock::{RawRwLock, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use cfg_if::cfg_if;
+use crossbeam_utils::CachePadded;
 use core::borrow::Borrow;
 use core::fmt;
 use core::hash::{BuildHasher, Hash, Hasher};
@@ -87,7 +88,7 @@ fn ncb(shard_amount: usize) -> usize {
 /// This means that it is safe to ignore it across multiple threads.
 pub struct DashMap<K, V, S = RandomState> {
     shift: usize,
-    shards: Box<[RwLock<HashMap<K, V, S>>]>,
+    shards: Box<[CachePadded<RwLock<HashMap<K, V, S>>>]>,
     hasher: S,
 }
 
@@ -98,7 +99,7 @@ impl<K: Eq + Hash + Clone, V: Clone, S: Clone> Clone for DashMap<K, V, S> {
         for shard in self.shards.iter() {
             let shard = shard.read();
 
-            inner_shards.push(RwLock::new((*shard).clone()));
+            inner_shards.push(CachePadded::new(RwLock::new((*shard).clone())));
         }
 
         Self {
@@ -282,7 +283,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
         let cps = capacity / shard_amount;
 
         let shards = (0..shard_amount)
-            .map(|_| RwLock::new(HashMap::with_capacity_and_hasher(cps, hasher.clone())))
+            .map(|_| CachePadded::new(RwLock::new(HashMap::with_capacity_and_hasher(cps, hasher.clone()))))
             .collect();
 
         Self {
@@ -317,7 +318,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
             /// let map = DashMap::<(), ()>::new();
             /// println!("Amount of shards: {}", map.shards().len());
             /// ```
-            pub fn shards(&self) -> &[RwLock<HashMap<K, V, S>>] {
+            pub fn shards(&self) -> &[CachePadded<RwLock<HashMap<K, V, S>>>] {
                 &self.shards
             }
 
@@ -337,7 +338,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
             /// map.shards_mut()[shard_ind].get_mut().insert(42, SharedValue::new("forty two"));
             /// assert_eq!(*map.get(&42).unwrap(), "forty two");
             /// ```
-            pub fn shards_mut(&mut self) -> &mut [RwLock<HashMap<K, V, S>>] {
+            pub fn shards_mut(&mut self) -> &mut [CachePadded<RwLock<HashMap<K, V, S>>>] {
                 &mut self.shards
             }
 
@@ -347,22 +348,22 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
             /// Requires the `raw-api` feature to be enabled.
             ///
             /// See [`DashMap::shards()`] and [`DashMap::shards_mut()`] for more information.
-            pub fn into_shards(self) -> Box<[RwLock<HashMap<K, V, S>>]> {
+            pub fn into_shards(self) -> Box<[CachePadded<RwLock<HashMap<K, V, S>>>]> {
                 self.shards
             }
         } else {
             #[allow(dead_code)]
-            pub(crate) fn shards(&self) -> &[RwLock<HashMap<K, V, S>>] {
+            pub(crate) fn shards(&self) -> &[CachePadded<RwLock<HashMap<K, V, S>>>] {
                 &self.shards
             }
 
             #[allow(dead_code)]
-            pub(crate) fn shards_mut(&mut self) -> &mut [RwLock<HashMap<K, V, S>>] {
+            pub(crate) fn shards_mut(&mut self) -> &mut [CachePadded<RwLock<HashMap<K, V, S>>>] {
                 &mut self.shards
             }
 
             #[allow(dead_code)]
-            pub(crate) fn into_shards(self) -> Box<[RwLock<HashMap<K, V, S>>]> {
+            pub(crate) fn into_shards(self) -> Box<[CachePadded<RwLock<HashMap<K, V, S>>>]> {
                 self.shards
             }
         }

--- a/src/read_only.rs
+++ b/src/read_only.rs
@@ -5,6 +5,7 @@ use cfg_if::cfg_if;
 use core::borrow::Borrow;
 use core::fmt;
 use core::hash::{BuildHasher, Hash};
+use crossbeam_utils::CachePadded;
 use std::collections::hash_map::RandomState;
 
 /// A read-only view into a `DashMap`. Allows to obtain raw references to the stored values.
@@ -139,12 +140,12 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> ReadOnlyView<K, V, S>
             /// let map = DashMap::<(), ()>::new().into_read_only();
             /// println!("Amount of shards: {}", map.shards().len());
             /// ```
-            pub fn shards(&self) -> &[RwLock<HashMap<K, V, S>>] {
+            pub fn shards(&self) -> &[CachePadded<RwLock<HashMap<K, V, S>>>] {
                 &self.map.shards
             }
         } else {
             #[allow(dead_code)]
-            pub(crate) fn shards(&self) -> &[RwLock<HashMap<K, V, S>>] {
+            pub(crate) fn shards(&self) -> &[CachePadded<RwLock<HashMap<K, V, S>>>] {
                 &self.map.shards
             }
         }

--- a/src/set.rs
+++ b/src/set.rs
@@ -10,6 +10,8 @@ use core::borrow::Borrow;
 use core::fmt;
 use core::hash::{BuildHasher, Hash};
 use core::iter::FromIterator;
+#[cfg(feature = "raw-api")]
+use crossbeam_utils::CachePadded;
 use std::collections::hash_map::RandomState;
 
 /// DashSet is a thin wrapper around [`DashMap`] using `()` as the value type. It uses
@@ -136,7 +138,7 @@ impl<'a, K: 'a + Eq + Hash, S: BuildHasher + Clone> DashSet<K, S> {
             /// let set = DashSet::<()>::new();
             /// println!("Amount of shards: {}", set.shards().len());
             /// ```
-            pub fn shards(&self) -> &[RwLock<HashMap<K, (), S>>] {
+            pub fn shards(&self) -> &[CachePadded<RwLock<HashMap<K, (), S>>>] {
                 self.inner.shards()
             }
         }


### PR DESCRIPTION
Using CachePadded to cache-align the rwlock shards for improved locking performance. This offers _considerable_ (30-50%) improvements in both latency and throughput perf on my M2.

> [!NOTE]  
> This increases memory usage. On x86_64, the cache alignment is set to 128. The current size of `RwLock<HashMap<K, V, std::RandomState>>` is `8 + 16 + 32 = 56` bytes. The current size of `RwLock<HashMap<K, V, ahash::RandomState>>` is `8 + 32 + 32 = 72` bytes. So this will double the size of the **empty** collection. Eg on a 64 core CPU the empty std dashmap size will increase from 14KiB to 32KiB. This size increase is constant though and does not scale per element inserted into the map.

> [!IMPORTANT]  
> This is a breaking change for the raw shards api.

<details>
<summary>Benchmark results</summary>

In this benchmark, 
* `DashMap` is the released version 5.3.3
* `DashMap2` is this version

![RapidGrow ahash latency](https://github.com/xacrimon/dashmap/assets/6625462/7731b79d-58ad-448b-95f3-02af3ece552b)
![RapidGrow ahash throughput](https://github.com/xacrimon/dashmap/assets/6625462/f9ac7205-a998-4499-aafd-8b2eb1bd9b1a)

![Exchange ahash latency](https://github.com/xacrimon/dashmap/assets/6625462/282c1fdd-4770-42db-82d4-862402340072)
![Exchange ahash throughput](https://github.com/xacrimon/dashmap/assets/6625462/d9df275a-764e-438f-a407-ce8d2aa52823)

![ReadHeavy ahash latency](https://github.com/xacrimon/dashmap/assets/6625462/a1df8f2b-795f-4eff-be9c-0e5bad97d79e)
![ReadHeavy ahash throughput](https://github.com/xacrimon/dashmap/assets/6625462/2a578ab7-9fcb-4338-bbfe-a8a63a7fa85e)

![RapidGrow std latency](https://github.com/xacrimon/dashmap/assets/6625462/7d62c04b-11db-4b04-be99-f78ddb4b9443)
![RapidGrow std throughput](https://github.com/xacrimon/dashmap/assets/6625462/e9369989-ffc8-4715-adf8-5ac8b14ee0cc)

![Exchange std latency](https://github.com/xacrimon/dashmap/assets/6625462/1b4fe856-4990-4d0b-90f2-66ce39cb2c6a)
![Exchange std throughput](https://github.com/xacrimon/dashmap/assets/6625462/0d9b75fa-cc5a-460d-97f1-4c4255ee4de3)

![ReadHeavy std latency](https://github.com/xacrimon/dashmap/assets/6625462/64cbbb63-ab65-492d-9b19-94fbfe1af29c)
![ReadHeavy std throughput](https://github.com/xacrimon/dashmap/assets/6625462/16fa5dfd-2794-400f-a64c-27f09a29c04f)

</details>