### PR TITLE
Set readme contents as crate docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc = include_str!("../README.md")]
 #![allow(clippy::type_complexity)]
 
 #[cfg(feature = "arbitrary")]


### PR DESCRIPTION
The dashmap page on docs.rs looked a little bit empty. This should fix it.