### PR TITLE
update hashbrown to v0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "7.0.0"
 dependencies = [
  "arbitrary",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,9 +93,9 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "hermit-abi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ keywords = ["atomic", "concurrent", "hashmap"]
 categories = ["concurrency", "algorithms", "data-structures"]
 
 [features]
-default = []
 raw-api = []
 typesize = ["dep:typesize"]
 inline = ["hashbrown/inline-more"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["atomic", "concurrent", "hashmap"]
 categories = ["concurrency", "algorithms", "data-structures"]
 
 [features]
+default = []
 raw-api = []
 typesize = ["dep:typesize"]
 inline = ["hashbrown/inline-more"]
@@ -21,7 +22,7 @@ inline = ["hashbrown/inline-more"]
 [dependencies]
 lock_api = "0.4.10"
 parking_lot_core = "0.9.8"
-hashbrown = { version = "0.14.0", default-features = false, features = ["raw"] }
+hashbrown = { version = "0.15.0", default-features = false }
 serde = { version = "1.0.188", optional = true, features = ["derive"] }
 cfg-if = "1.0.0"
 rayon = { version = "1.7.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dashmap"
-version = "6.1.0"
+version = "7.0.0"
 authors = ["Acrimon <joel.wejdenstal@gmail.com>"]
 edition = "2018"
 rust-version = "1.65"

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -125,6 +125,7 @@ impl<'a, K: Eq + Hash, V, S: 'a + BuildHasher + Clone, M: Map<'a, K, V, S>> Iter
             if let Some(current) = self.current.as_mut() {
                 if let Some(data) = current.1.next() {
                     let guard = current.0.clone();
+                    // Safety: The guard still protects the data
                     return unsafe { Some(RefMulti::new(guard, data)) };
                 }
             }
@@ -187,6 +188,7 @@ impl<'a, K: Eq + Hash, V, S: 'a + BuildHasher + Clone, M: Map<'a, K, V, S>> Iter
             if let Some(current) = self.current.as_mut() {
                 if let Some(data) = current.1.next() {
                     let guard = current.0.clone();
+                    // Safety: The guard still protects the data
                     return unsafe { Some(RefMutMulti::new(guard, data)) };
                 }
             }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,7 +1,6 @@
 use super::mapref::multiple::{RefMulti, RefMutMulti};
 use crate::lock::{RwLockReadGuardDetached, RwLockWriteGuardDetached};
 use crate::t::Map;
-use crate::util::SharedValue;
 use crate::DashMap;
 use core::hash::{BuildHasher, Hash};
 use core::mem;
@@ -38,7 +37,7 @@ impl<K: Eq + Hash, V, S: BuildHasher + Clone> OwningIter<K, V, S> {
     }
 }
 
-type GuardOwningIter<K, V> = hashbrown::hash_table::IntoIter<(K, SharedValue<V>)>;
+type GuardOwningIter<K, V> = hashbrown::hash_table::IntoIter<(K, V)>;
 
 impl<K: Eq + Hash, V, S: BuildHasher + Clone> Iterator for OwningIter<K, V, S> {
     type Item = (K, V);
@@ -46,8 +45,8 @@ impl<K: Eq + Hash, V, S: BuildHasher + Clone> Iterator for OwningIter<K, V, S> {
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(current) = self.current.as_mut() {
-                if let Some((k, v)) = current.next() {
-                    return Some((k, v.into_inner()));
+                if let Some(value) = current.next() {
+                    return Some(value);
                 }
             }
 
@@ -74,12 +73,12 @@ impl<K: Eq + Hash, V, S: BuildHasher + Clone> Iterator for OwningIter<K, V, S> {
 
 type GuardIter<'a, K, V> = (
     Arc<RwLockReadGuardDetached<'a>>,
-    hashbrown::hash_table::Iter<'a, (K, SharedValue<V>)>,
+    hashbrown::hash_table::Iter<'a, (K, V)>,
 );
 
 type GuardIterMut<'a, K, V> = (
     Arc<RwLockWriteGuardDetached<'a>>,
-    hashbrown::hash_table::IterMut<'a, (K, SharedValue<V>)>,
+    hashbrown::hash_table::IterMut<'a, (K, V)>,
 );
 
 /// Iterator over a DashMap yielding immutable references.

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -72,22 +72,6 @@ impl<K: Eq + Hash, V, S: BuildHasher + Clone> Iterator for OwningIter<K, V, S> {
     }
 }
 
-unsafe impl<K, V, S> Send for OwningIter<K, V, S>
-where
-    K: Eq + Hash + Send,
-    V: Send,
-    S: BuildHasher + Clone + Send,
-{
-}
-
-unsafe impl<K, V, S> Sync for OwningIter<K, V, S>
-where
-    K: Eq + Hash + Sync,
-    V: Sync,
-    S: BuildHasher + Clone + Sync,
-{
-}
-
 type GuardIter<'a, K, V> = (
     Arc<RwLockReadGuardDetached<'a>>,
     hashbrown::hash_table::Iter<'a, (K, SharedValue<V>)>,
@@ -122,24 +106,6 @@ impl<'i, K: Clone + Hash + Eq, V: Clone, S: Clone + BuildHasher> Clone for Iter<
     }
 }
 
-unsafe impl<'a, 'i, K, V, S, M> Send for Iter<'i, K, V, S, M>
-where
-    K: 'a + Eq + Hash + Send,
-    V: 'a + Send,
-    S: 'a + BuildHasher + Clone,
-    M: Map<'a, K, V, S>,
-{
-}
-
-unsafe impl<'a, 'i, K, V, S, M> Sync for Iter<'i, K, V, S, M>
-where
-    K: 'a + Eq + Hash + Sync,
-    V: 'a + Sync,
-    S: 'a + BuildHasher + Clone,
-    M: Map<'a, K, V, S>,
-{
-}
-
 impl<'a, K: Eq + Hash, V, S: 'a + BuildHasher + Clone, M: Map<'a, K, V, S>> Iter<'a, K, V, S, M> {
     pub(crate) fn new(map: &'a M) -> Self {
         Self {
@@ -156,7 +122,6 @@ impl<'a, K: Eq + Hash, V, S: 'a + BuildHasher + Clone, M: Map<'a, K, V, S>> Iter
 {
     type Item = RefMulti<'a, K, V>;
 
-    #[allow(clippy::arc_with_non_send_sync)]
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(current) = self.current.as_mut() {
@@ -201,24 +166,6 @@ pub struct IterMut<'a, K, V, S = RandomState, M = DashMap<K, V, S>> {
     marker: PhantomData<S>,
 }
 
-unsafe impl<'a, 'i, K, V, S, M> Send for IterMut<'i, K, V, S, M>
-where
-    K: 'a + Eq + Hash + Send,
-    V: 'a + Send,
-    S: 'a + BuildHasher + Clone,
-    M: Map<'a, K, V, S>,
-{
-}
-
-unsafe impl<'a, 'i, K, V, S, M> Sync for IterMut<'i, K, V, S, M>
-where
-    K: 'a + Eq + Hash + Sync,
-    V: 'a + Sync,
-    S: 'a + BuildHasher + Clone,
-    M: Map<'a, K, V, S>,
-{
-}
-
 impl<'a, K: Eq + Hash, V, S: 'a + BuildHasher + Clone, M: Map<'a, K, V, S>>
     IterMut<'a, K, V, S, M>
 {
@@ -237,7 +184,6 @@ impl<'a, K: Eq + Hash, V, S: 'a + BuildHasher + Clone, M: Map<'a, K, V, S>> Iter
 {
     type Item = RefMutMulti<'a, K, V>;
 
-    #[allow(clippy::arc_with_non_send_sync)]
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(current) = self.current.as_mut() {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -160,10 +160,10 @@ impl<'a, K: Eq + Hash, V, S: 'a + BuildHasher + Clone, M: Map<'a, K, V, S>> Iter
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(current) = self.current.as_mut() {
-                if let Some((k, v)) = current.1.next() {
+                if let Some(data) = current.1.next() {
                     return unsafe {
                         let guard = current.0.clone();
-                        Some(RefMulti::new(guard, k, v.get()))
+                        Some(RefMulti::new(guard, data))
                     };
                 }
             }
@@ -244,10 +244,10 @@ impl<'a, K: Eq + Hash, V, S: 'a + BuildHasher + Clone, M: Map<'a, K, V, S>> Iter
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(current) = self.current.as_mut() {
-                if let Some((k, v)) = current.1.next() {
+                if let Some(data) = current.1.next() {
                     return unsafe {
                         let guard = current.0.clone();
-                        Some(RefMutMulti::new(guard, k, v.get_mut()))
+                        Some(RefMutMulti::new(guard, data))
                     };
                 }
             }

--- a/src/iter_set.rs
+++ b/src/iter_set.rs
@@ -20,38 +20,8 @@ impl<K: Eq + Hash, S: BuildHasher + Clone> Iterator for OwningIter<K, S> {
     }
 }
 
-unsafe impl<K, S> Send for OwningIter<K, S>
-where
-    K: Eq + Hash + Send,
-    S: BuildHasher + Clone + Send,
-{
-}
-
-unsafe impl<K, S> Sync for OwningIter<K, S>
-where
-    K: Eq + Hash + Sync,
-    S: BuildHasher + Clone + Sync,
-{
-}
-
 pub struct Iter<'a, K, S, M> {
     inner: crate::iter::Iter<'a, K, (), S, M>,
-}
-
-unsafe impl<'a, 'i, K, S, M> Send for Iter<'i, K, S, M>
-where
-    K: 'a + Eq + Hash + Send,
-    S: 'a + BuildHasher + Clone,
-    M: Map<'a, K, (), S>,
-{
-}
-
-unsafe impl<'a, 'i, K, S, M> Sync for Iter<'i, K, S, M>
-where
-    K: 'a + Eq + Hash + Sync,
-    S: 'a + BuildHasher + Clone,
-    M: Map<'a, K, (), S>,
-{
 }
 
 impl<'a, K: Eq + Hash, S: 'a + BuildHasher + Clone, M: Map<'a, K, (), S>> Iter<'a, K, S, M> {

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -22,7 +22,7 @@ unsafe impl lock_api::RawRwLock for RawRwLock {
         state: AtomicUsize::new(0),
     };
 
-    type GuardMarker = lock_api::GuardNoSend;
+    type GuardMarker = lock_api::GuardSend;
 
     #[inline]
     fn try_lock_exclusive(&self) -> bool {

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -4,6 +4,8 @@ use parking_lot_core::{ParkToken, SpinWait, UnparkToken};
 pub type RwLock<T> = lock_api::RwLock<RawRwLock, T>;
 pub type RwLockReadGuard<'a, T> = lock_api::RwLockReadGuard<'a, RawRwLock, T>;
 pub type RwLockWriteGuard<'a, T> = lock_api::RwLockWriteGuard<'a, RawRwLock, T>;
+pub(crate) type RwLockReadGuardDetached<'a> = crate::util::RwLockReadGuardDetached<'a, RawRwLock>;
+pub(crate) type RwLockWriteGuardDetached<'a> = crate::util::RwLockWriteGuardDetached<'a, RawRwLock>;
 
 const READERS_PARKED: usize = 0b0001;
 const WRITERS_PARKED: usize = 0b0010;

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -82,7 +82,9 @@ unsafe impl lock_api::RawRwLockDowngrade for RawRwLock {
             .state
             .fetch_and(ONE_READER | WRITERS_PARKED, Ordering::Release);
         if state & READERS_PARKED != 0 {
-            parking_lot_core::unpark_all((self as *const _ as usize) + 1, UnparkToken(0));
+            unsafe {
+                parking_lot_core::unpark_all((self as *const _ as usize) + 1, UnparkToken(0));
+            }
         }
     }
 }

--- a/src/mapref/entry.rs
+++ b/src/mapref/entry.rs
@@ -1,6 +1,5 @@
 use super::one::RefMut;
-use crate::util::SharedValue;
-use crate::GuardWrite;
+use crate::util::{GuardWrite, SharedValue};
 use core::hash::Hash;
 use core::mem;
 use hashbrown::hash_table;

--- a/src/mapref/entry.rs
+++ b/src/mapref/entry.rs
@@ -117,9 +117,6 @@ pub struct VacantEntry<'a, K, V> {
     key: K,
 }
 
-unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Send for VacantEntry<'a, K, V> {}
-unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Sync for VacantEntry<'a, K, V> {}
-
 impl<'a, K: Eq + Hash, V> VacantEntry<'a, K, V> {
     pub(crate) unsafe fn new(
         guard: RwLockWriteGuardDetached<'a>,
@@ -163,9 +160,6 @@ pub struct OccupiedEntry<'a, K, V> {
     entry: hash_table::OccupiedEntry<'a, (K, SharedValue<V>)>,
     key: K,
 }
-
-unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Send for OccupiedEntry<'a, K, V> {}
-unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Sync for OccupiedEntry<'a, K, V> {}
 
 impl<'a, K: Eq + Hash, V> OccupiedEntry<'a, K, V> {
     pub(crate) unsafe fn new(

--- a/src/mapref/entry.rs
+++ b/src/mapref/entry.rs
@@ -1,5 +1,6 @@
 use super::one::RefMut;
-use crate::util::{GuardWrite, SharedValue};
+use crate::lock::RwLockWriteGuardDetached;
+use crate::util::SharedValue;
 use core::hash::Hash;
 use core::mem;
 use hashbrown::hash_table;
@@ -111,7 +112,7 @@ impl<'a, K: Eq + Hash, V> Entry<'a, K, V> {
 }
 
 pub struct VacantEntry<'a, K, V> {
-    guard: GuardWrite<'a>,
+    guard: RwLockWriteGuardDetached<'a>,
     entry: hash_table::VacantEntry<'a, (K, SharedValue<V>)>,
     key: K,
 }
@@ -121,7 +122,7 @@ unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Sync for VacantEntry<'a, K, V> {}
 
 impl<'a, K: Eq + Hash, V> VacantEntry<'a, K, V> {
     pub(crate) unsafe fn new(
-        guard: GuardWrite<'a>,
+        guard: RwLockWriteGuardDetached<'a>,
         entry: hash_table::VacantEntry<'a, (K, SharedValue<V>)>,
         key: K,
     ) -> Self {
@@ -158,7 +159,7 @@ impl<'a, K: Eq + Hash, V> VacantEntry<'a, K, V> {
 }
 
 pub struct OccupiedEntry<'a, K, V> {
-    guard: GuardWrite<'a>,
+    guard: RwLockWriteGuardDetached<'a>,
     entry: hash_table::OccupiedEntry<'a, (K, SharedValue<V>)>,
     key: K,
 }
@@ -168,7 +169,7 @@ unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Sync for OccupiedEntry<'a, K, V> {
 
 impl<'a, K: Eq + Hash, V> OccupiedEntry<'a, K, V> {
     pub(crate) unsafe fn new(
-        guard: GuardWrite<'a>,
+        guard: RwLockWriteGuardDetached<'a>,
         entry: hash_table::OccupiedEntry<'a, (K, SharedValue<V>)>,
         key: K,
     ) -> Self {

--- a/src/mapref/multiple.rs
+++ b/src/mapref/multiple.rs
@@ -1,11 +1,10 @@
-use crate::lock::{RwLockReadGuard, RwLockWriteGuard};
-use crate::HashMap;
+use crate::{GuardRead, GuardWrite};
 use core::hash::Hash;
 use core::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
 pub struct RefMulti<'a, K, V> {
-    _guard: Arc<RwLockReadGuard<'a, HashMap<K, V>>>,
+    _guard: Arc<GuardRead<'a>>,
     k: *const K,
     v: *const V,
 }
@@ -14,11 +13,7 @@ unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Send for RefMulti<'a, K, V> {}
 unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Sync for RefMulti<'a, K, V> {}
 
 impl<'a, K: Eq + Hash, V> RefMulti<'a, K, V> {
-    pub(crate) unsafe fn new(
-        guard: Arc<RwLockReadGuard<'a, HashMap<K, V>>>,
-        k: *const K,
-        v: *const V,
-    ) -> Self {
+    pub(crate) unsafe fn new(guard: Arc<GuardRead<'a>>, k: *const K, v: *const V) -> Self {
         Self {
             _guard: guard,
             k,
@@ -48,7 +43,7 @@ impl<'a, K: Eq + Hash, V> Deref for RefMulti<'a, K, V> {
 }
 
 pub struct RefMutMulti<'a, K, V> {
-    _guard: Arc<RwLockWriteGuard<'a, HashMap<K, V>>>,
+    _guard: Arc<GuardWrite<'a>>,
     k: *const K,
     v: *mut V,
 }
@@ -57,11 +52,7 @@ unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Send for RefMutMulti<'a, K, V> {}
 unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Sync for RefMutMulti<'a, K, V> {}
 
 impl<'a, K: Eq + Hash, V> RefMutMulti<'a, K, V> {
-    pub(crate) unsafe fn new(
-        guard: Arc<RwLockWriteGuard<'a, HashMap<K, V>>>,
-        k: *const K,
-        v: *mut V,
-    ) -> Self {
+    pub(crate) unsafe fn new(guard: Arc<GuardWrite<'a>>, k: *const K, v: *mut V) -> Self {
         Self {
             _guard: guard,
             k,

--- a/src/mapref/multiple.rs
+++ b/src/mapref/multiple.rs
@@ -1,10 +1,11 @@
-use crate::util::{GuardRead, GuardWrite, SharedValue};
+use crate::lock::{RwLockReadGuardDetached, RwLockWriteGuardDetached};
+use crate::util::SharedValue;
 use core::hash::Hash;
 use core::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
 pub struct RefMulti<'a, K, V> {
-    _guard: Arc<GuardRead<'a>>,
+    _guard: Arc<RwLockReadGuardDetached<'a>>,
     data: &'a (K, SharedValue<V>),
 }
 
@@ -12,7 +13,10 @@ unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Send for RefMulti<'a, K, V> {}
 unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Sync for RefMulti<'a, K, V> {}
 
 impl<'a, K: Eq + Hash, V> RefMulti<'a, K, V> {
-    pub(crate) unsafe fn new(guard: Arc<GuardRead<'a>>, data: &'a (K, SharedValue<V>)) -> Self {
+    pub(crate) unsafe fn new(
+        guard: Arc<RwLockReadGuardDetached<'a>>,
+        data: &'a (K, SharedValue<V>),
+    ) -> Self {
         Self {
             _guard: guard,
             data,
@@ -41,7 +45,7 @@ impl<'a, K: Eq + Hash, V> Deref for RefMulti<'a, K, V> {
 }
 
 pub struct RefMutMulti<'a, K, V> {
-    _guard: Arc<GuardWrite<'a>>,
+    _guard: Arc<RwLockWriteGuardDetached<'a>>,
     data: &'a mut (K, SharedValue<V>),
 }
 
@@ -50,7 +54,7 @@ unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Sync for RefMutMulti<'a, K, V> {}
 
 impl<'a, K: Eq + Hash, V> RefMutMulti<'a, K, V> {
     pub(crate) unsafe fn new(
-        guard: Arc<GuardWrite<'a>>,
+        guard: Arc<RwLockWriteGuardDetached<'a>>,
         data: &'a mut (K, SharedValue<V>),
     ) -> Self {
         Self {

--- a/src/mapref/multiple.rs
+++ b/src/mapref/multiple.rs
@@ -1,19 +1,15 @@
 use crate::lock::{RwLockReadGuardDetached, RwLockWriteGuardDetached};
-use crate::util::SharedValue;
 use core::hash::Hash;
 use core::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
 pub struct RefMulti<'a, K, V> {
     _guard: Arc<RwLockReadGuardDetached<'a>>,
-    data: &'a (K, SharedValue<V>),
+    data: &'a (K, V),
 }
 
 impl<'a, K: Eq + Hash, V> RefMulti<'a, K, V> {
-    pub(crate) unsafe fn new(
-        guard: Arc<RwLockReadGuardDetached<'a>>,
-        data: &'a (K, SharedValue<V>),
-    ) -> Self {
+    pub(crate) unsafe fn new(guard: Arc<RwLockReadGuardDetached<'a>>, data: &'a (K, V)) -> Self {
         Self {
             _guard: guard,
             data,
@@ -29,7 +25,7 @@ impl<'a, K: Eq + Hash, V> RefMulti<'a, K, V> {
     }
 
     pub fn pair(&self) -> (&K, &V) {
-        (&self.data.0, self.data.1.get())
+        (&self.data.0, &self.data.1)
     }
 }
 
@@ -43,13 +39,13 @@ impl<'a, K: Eq + Hash, V> Deref for RefMulti<'a, K, V> {
 
 pub struct RefMutMulti<'a, K, V> {
     _guard: Arc<RwLockWriteGuardDetached<'a>>,
-    data: &'a mut (K, SharedValue<V>),
+    data: &'a mut (K, V),
 }
 
 impl<'a, K: Eq + Hash, V> RefMutMulti<'a, K, V> {
     pub(crate) unsafe fn new(
         guard: Arc<RwLockWriteGuardDetached<'a>>,
-        data: &'a mut (K, SharedValue<V>),
+        data: &'a mut (K, V),
     ) -> Self {
         Self {
             _guard: guard,
@@ -70,11 +66,11 @@ impl<'a, K: Eq + Hash, V> RefMutMulti<'a, K, V> {
     }
 
     pub fn pair(&self) -> (&K, &V) {
-        (&self.data.0, self.data.1.get())
+        (&self.data.0, &self.data.1)
     }
 
     pub fn pair_mut(&mut self) -> (&K, &mut V) {
-        (&self.data.0, self.data.1.get_mut())
+        (&self.data.0, &mut self.data.1)
     }
 }
 

--- a/src/mapref/multiple.rs
+++ b/src/mapref/multiple.rs
@@ -9,9 +9,6 @@ pub struct RefMulti<'a, K, V> {
     data: &'a (K, SharedValue<V>),
 }
 
-unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Send for RefMulti<'a, K, V> {}
-unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Sync for RefMulti<'a, K, V> {}
-
 impl<'a, K: Eq + Hash, V> RefMulti<'a, K, V> {
     pub(crate) unsafe fn new(
         guard: Arc<RwLockReadGuardDetached<'a>>,
@@ -48,9 +45,6 @@ pub struct RefMutMulti<'a, K, V> {
     _guard: Arc<RwLockWriteGuardDetached<'a>>,
     data: &'a mut (K, SharedValue<V>),
 }
-
-unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Send for RefMutMulti<'a, K, V> {}
-unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Sync for RefMutMulti<'a, K, V> {}
 
 impl<'a, K: Eq + Hash, V> RefMutMulti<'a, K, V> {
     pub(crate) unsafe fn new(

--- a/src/mapref/multiple.rs
+++ b/src/mapref/multiple.rs
@@ -1,5 +1,4 @@
-use crate::util::SharedValue;
-use crate::{GuardRead, GuardWrite};
+use crate::util::{GuardRead, GuardWrite, SharedValue};
 use core::hash::Hash;
 use core::ops::{Deref, DerefMut};
 use std::sync::Arc;

--- a/src/mapref/one.rs
+++ b/src/mapref/one.rs
@@ -171,8 +171,8 @@ impl<'a, K: Eq + Hash, V> DerefMut for RefMut<'a, K, V> {
 
 pub struct MappedRef<'a, K, T> {
     _guard: GuardRead<'a>,
-    k: *const K,
-    v: *const T,
+    k: &'a K,
+    v: &'a T,
 }
 
 impl<'a, K: Eq + Hash, T> MappedRef<'a, K, T> {
@@ -185,7 +185,7 @@ impl<'a, K: Eq + Hash, T> MappedRef<'a, K, T> {
     }
 
     pub fn pair(&self) -> (&K, &T) {
-        unsafe { (&*self.k, &*self.v) }
+        (self.k, self.v)
     }
 
     pub fn map<F, T2>(self, f: F) -> MappedRef<'a, K, T2>
@@ -195,7 +195,7 @@ impl<'a, K: Eq + Hash, T> MappedRef<'a, K, T> {
         MappedRef {
             _guard: self._guard,
             k: self.k,
-            v: f(unsafe { &*self.v }),
+            v: f(self.v),
         }
     }
 
@@ -203,7 +203,7 @@ impl<'a, K: Eq + Hash, T> MappedRef<'a, K, T> {
     where
         F: FnOnce(&T) -> Option<&T2>,
     {
-        let v = match f(unsafe { &*self.v }) {
+        let v = match f(self.v) {
             Some(v) => v,
             None => return Err(self),
         };

--- a/src/mapref/one.rs
+++ b/src/mapref/one.rs
@@ -10,9 +10,6 @@ pub struct Ref<'a, K, V> {
     data: &'a (K, SharedValue<V>),
 }
 
-unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Send for Ref<'a, K, V> {}
-unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Sync for Ref<'a, K, V> {}
-
 impl<'a, K: Eq + Hash, V> Ref<'a, K, V> {
     pub(crate) unsafe fn new(
         guard: RwLockReadGuardDetached<'a>,
@@ -81,9 +78,6 @@ pub struct RefMut<'a, K, V> {
     guard: RwLockWriteGuardDetached<'a>,
     data: &'a mut (K, SharedValue<V>),
 }
-
-unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Send for RefMut<'a, K, V> {}
-unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Sync for RefMut<'a, K, V> {}
 
 impl<'a, K: Eq + Hash, V> RefMut<'a, K, V> {
     pub(crate) unsafe fn new(

--- a/src/mapref/one.rs
+++ b/src/mapref/one.rs
@@ -10,6 +10,8 @@ pub struct Ref<'a, K, V> {
 }
 
 impl<'a, K: Eq + Hash, V> Ref<'a, K, V> {
+    /// # Safety
+    /// The guard should be protecting the provided data.
     pub(crate) unsafe fn new(guard: RwLockReadGuardDetached<'a>, data: &'a (K, V)) -> Self {
         Self { guard, data }
     }
@@ -76,6 +78,8 @@ pub struct RefMut<'a, K, V> {
 }
 
 impl<'a, K: Eq + Hash, V> RefMut<'a, K, V> {
+    /// # Safety
+    /// The guard should be protecting the provided data.
     pub(crate) unsafe fn new(guard: RwLockWriteGuardDetached<'a>, data: &'a mut (K, V)) -> Self {
         Self { guard, data }
     }

--- a/src/mapref/one.rs
+++ b/src/mapref/one.rs
@@ -1,10 +1,8 @@
-use lock_api::RawRwLockDowngrade;
-
-use crate::{GuardRead, GuardWrite, SharedValue};
+use crate::util::{GuardRead, GuardWrite};
+use crate::SharedValue;
 use core::hash::Hash;
 use core::ops::{Deref, DerefMut};
 use std::fmt::{Debug, Formatter};
-use std::mem::ManuallyDrop;
 use std::ptr::addr_of;
 
 pub struct Ref<'a, K, V> {
@@ -110,11 +108,7 @@ impl<'a, K: Eq + Hash, V> RefMut<'a, K, V> {
     }
 
     pub fn downgrade(self) -> Ref<'a, K, V> {
-        unsafe {
-            let guard = ManuallyDrop::new(self.guard);
-            guard.0.downgrade();
-            Ref::new(GuardRead(guard.0), &*addr_of!(*self.data))
-        }
+        unsafe { Ref::new(self.guard.downgrade(), &*addr_of!(*self.data)) }
     }
 
     pub fn map<F, T>(self, f: F) -> MappedRefMut<'a, K, T>

--- a/src/mapref/one.rs
+++ b/src/mapref/one.rs
@@ -106,8 +106,7 @@ impl<'a, K: Eq + Hash, V> RefMut<'a, K, V> {
     }
 
     pub fn pair_mut(&mut self) -> (&K, &mut V) {
-        let (k, v) = &mut *self.data;
-        (k, v.get_mut())
+        (&self.data.0, self.data.1.get_mut())
     }
 
     pub fn downgrade(self) -> Ref<'a, K, V> {
@@ -270,7 +269,7 @@ impl<'a, K: Eq + Hash, T> MappedRefMut<'a, K, T> {
     }
 
     pub fn pair_mut(&mut self) -> (&K, &mut T) {
-        (self.k, &mut *self.v)
+        (self.k, self.v)
     }
 
     pub fn map<F, T2>(self, f: F) -> MappedRefMut<'a, K, T2>

--- a/src/mapref/one.rs
+++ b/src/mapref/one.rs
@@ -1,4 +1,4 @@
-use crate::util::{GuardRead, GuardWrite};
+use crate::lock::{RwLockReadGuardDetached, RwLockWriteGuardDetached};
 use crate::SharedValue;
 use core::hash::Hash;
 use core::ops::{Deref, DerefMut};
@@ -6,7 +6,7 @@ use std::fmt::{Debug, Formatter};
 use std::ptr::addr_of;
 
 pub struct Ref<'a, K, V> {
-    guard: GuardRead<'a>,
+    guard: RwLockReadGuardDetached<'a>,
     data: &'a (K, SharedValue<V>),
 }
 
@@ -14,7 +14,10 @@ unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Send for Ref<'a, K, V> {}
 unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Sync for Ref<'a, K, V> {}
 
 impl<'a, K: Eq + Hash, V> Ref<'a, K, V> {
-    pub(crate) unsafe fn new(guard: GuardRead<'a>, data: &'a (K, SharedValue<V>)) -> Self {
+    pub(crate) unsafe fn new(
+        guard: RwLockReadGuardDetached<'a>,
+        data: &'a (K, SharedValue<V>),
+    ) -> Self {
         Self { guard, data }
     }
 
@@ -75,7 +78,7 @@ impl<'a, K: Eq + Hash, V> Deref for Ref<'a, K, V> {
 }
 
 pub struct RefMut<'a, K, V> {
-    guard: GuardWrite<'a>,
+    guard: RwLockWriteGuardDetached<'a>,
     data: &'a mut (K, SharedValue<V>),
 }
 
@@ -83,7 +86,10 @@ unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Send for RefMut<'a, K, V> {}
 unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Sync for RefMut<'a, K, V> {}
 
 impl<'a, K: Eq + Hash, V> RefMut<'a, K, V> {
-    pub(crate) unsafe fn new(guard: GuardWrite<'a>, data: &'a mut (K, SharedValue<V>)) -> Self {
+    pub(crate) unsafe fn new(
+        guard: RwLockWriteGuardDetached<'a>,
+        data: &'a mut (K, SharedValue<V>),
+    ) -> Self {
         Self { guard, data }
     }
 
@@ -164,7 +170,7 @@ impl<'a, K: Eq + Hash, V> DerefMut for RefMut<'a, K, V> {
 }
 
 pub struct MappedRef<'a, K, T> {
-    _guard: GuardRead<'a>,
+    _guard: RwLockReadGuardDetached<'a>,
     k: &'a K,
     v: &'a T,
 }
@@ -240,7 +246,7 @@ impl<'a, K: Eq + Hash, T: AsRef<TDeref>, TDeref: ?Sized> AsRef<TDeref> for Mappe
 }
 
 pub struct MappedRefMut<'a, K, T> {
-    _guard: GuardWrite<'a>,
+    _guard: RwLockWriteGuardDetached<'a>,
     k: &'a K,
     v: &'a mut T,
 }

--- a/src/rayon/map.rs
+++ b/src/rayon/map.rs
@@ -1,6 +1,6 @@
 use crate::lock::{RwLock, RwLockReadGuardDetached, RwLockWriteGuardDetached};
 use crate::mapref::multiple::{RefMulti, RefMutMulti};
-use crate::{DashMap, HashMap};
+use crate::{DashMap, HashMap, Shard};
 use core::hash::{BuildHasher, Hash};
 use crossbeam_utils::CachePadded;
 use rayon::iter::plumbing::UnindexedConsumer;
@@ -79,7 +79,7 @@ where
 }
 
 pub struct OwningIter<K, V> {
-    pub(super) shards: Box<[CachePadded<RwLock<HashMap<K, V>>>]>,
+    pub(super) shards: Box<[Shard<K, V>]>,
 }
 
 impl<K, V> ParallelIterator for OwningIter<K, V>
@@ -118,7 +118,7 @@ where
 }
 
 pub struct Iter<'a, K, V> {
-    pub(super) shards: &'a [CachePadded<RwLock<HashMap<K, V>>>],
+    pub(super) shards: &'a [Shard<K, V>],
 }
 
 impl<'a, K, V> ParallelIterator for Iter<'a, K, V>

--- a/src/rayon/map.rs
+++ b/src/rayon/map.rs
@@ -134,7 +134,6 @@ where
 {
     type Item = RefMulti<'a, K, V>;
 
-    #[allow(clippy::arc_with_non_send_sync)]
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
     where
         C: UnindexedConsumer<Self::Item>,
@@ -194,7 +193,6 @@ where
 {
     type Item = RefMutMulti<'a, K, V>;
 
-    #[allow(clippy::arc_with_non_send_sync)]
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
     where
         C: UnindexedConsumer<Self::Item>,

--- a/src/rayon/map.rs
+++ b/src/rayon/map.rs
@@ -148,9 +148,9 @@ where
                 let guard = unsafe { GuardRead(rwlock.raw()) };
 
                 let guard = Arc::new(guard);
-                data.iter().map(move |(k, v)| {
+                data.iter().map(move |data| {
                     let guard = Arc::clone(&guard);
-                    unsafe { RefMulti::new(guard, k, v.get()) }
+                    unsafe { RefMulti::new(guard, data) }
                 })
             })
             .drive_unindexed(consumer)
@@ -209,9 +209,9 @@ where
                 let guard = unsafe { GuardWrite(rwlock.raw()) };
 
                 let guard = Arc::new(guard);
-                data.iter_mut().map(move |(k, v)| {
+                data.iter_mut().map(move |data| {
                     let guard = Arc::clone(&guard);
-                    unsafe { RefMutMulti::new(guard, k, v.get_mut()) }
+                    unsafe { RefMutMulti::new(guard, data) }
                 })
             })
             .drive_unindexed(consumer)

--- a/src/read_only.rs
+++ b/src/read_only.rs
@@ -86,10 +86,9 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> ReadOnlyView<K, V, S>
 
         let shard = unsafe { self.map._get_read_shard(idx) };
 
-        shard.find(hash, |(k, _v)| key == k.borrow()).map(|b| {
-            let (k, v) = unsafe { b.as_ref() };
-            (k, v.get())
-        })
+        shard
+            .find(hash, |(k, _v)| key == k.borrow())
+            .map(|(k, v)| (k, v.get()))
     }
 
     /// An iterator visiting all key-value pairs in arbitrary order. The iterator element type is `(&'a K, &'a V)`.
@@ -98,10 +97,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> ReadOnlyView<K, V, S>
             (0..self.map._shard_count())
                 .map(move |shard_i| self.map._get_read_shard(shard_i))
                 .flat_map(|shard| shard.iter())
-                .map(|b| {
-                    let (k, v) = b.as_ref();
-                    (k, v.get())
-                })
+                .map(|(k, v)| (k, v.get()))
         }
     }
 

--- a/src/read_only.rs
+++ b/src/read_only.rs
@@ -84,6 +84,8 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> ReadOnlyView<K, V, S>
 
         let idx = self.map.determine_shard(hash as usize);
 
+        // Safety: shard index is in bounds
+        // and this is a read-only view.
         let shard = unsafe { self.map._get_read_shard(idx) };
 
         shard
@@ -93,12 +95,12 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> ReadOnlyView<K, V, S>
 
     /// An iterator visiting all key-value pairs in arbitrary order. The iterator element type is `(&'a K, &'a V)`.
     pub fn iter(&'a self) -> impl Iterator<Item = (&'a K, &'a V)> + 'a {
-        unsafe {
-            (0..self.map._shard_count())
-                .map(move |shard_i| self.map._get_read_shard(shard_i))
-                .flat_map(|shard| shard.iter())
-                .map(|(k, v)| (k, v))
-        }
+        (0..self.map._shard_count())
+            // Safety: shard index is in bounds
+            // and this is a read-only view.
+            .map(move |shard_i| unsafe { self.map._get_read_shard(shard_i) })
+            .flat_map(|shard| shard.iter())
+            .map(|(k, v)| (k, v))
     }
 
     /// An iterator visiting all keys in arbitrary order. The iterator element type is `&'a K`.

--- a/src/read_only.rs
+++ b/src/read_only.rs
@@ -88,7 +88,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> ReadOnlyView<K, V, S>
 
         shard
             .find(hash, |(k, _v)| key == k.borrow())
-            .map(|(k, v)| (k, v.get()))
+            .map(|(k, v)| (k, v))
     }
 
     /// An iterator visiting all key-value pairs in arbitrary order. The iterator element type is `(&'a K, &'a V)`.
@@ -97,7 +97,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> ReadOnlyView<K, V, S>
             (0..self.map._shard_count())
                 .map(move |shard_i| self.map._get_read_shard(shard_i))
                 .flat_map(|shard| shard.iter())
-                .map(|(k, v)| (k, v.get()))
+                .map(|(k, v)| (k, v))
         }
     }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -7,6 +7,7 @@ use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 use serde::Deserializer;
 
 pub struct DashMapVisitor<K, V, S> {
+    #[allow(clippy::type_complexity)]
     marker: PhantomData<fn() -> DashMap<K, V, S>>,
 }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -185,11 +185,11 @@ impl<'a, K: Eq + Hash, V: Serialize> Serialize for mapref::one::RefMut<'a, K, V>
     serialize_impl! {}
 }
 
-impl<'a, K: Eq + Hash, V, T: Serialize> Serialize for mapref::one::MappedRef<'a, K, V, T> {
+impl<'a, K: Eq + Hash, T: Serialize> Serialize for mapref::one::MappedRef<'a, K, T> {
     serialize_impl! {}
 }
 
-impl<'a, K: Eq + Hash, V, T: Serialize> Serialize for mapref::one::MappedRefMut<'a, K, V, T> {
+impl<'a, K: Eq + Hash, T: Serialize> Serialize for mapref::one::MappedRefMut<'a, K, T> {
     serialize_impl! {}
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -72,11 +72,6 @@ impl<T> SharedValue<T> {
     pub fn into_inner(self) -> T {
         self.value.into_inner()
     }
-
-    /// Get a mutable raw pointer to the underlying value
-    pub(crate) fn as_ptr(&self) -> *mut T {
-        self.value.get()
-    }
 }
 
 struct AbortOnPanic;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,5 @@
 //! This module is full of hackery and dark magic.
 //! Either spend a day fixing it and quietly submit a PR or don't mention it to anybody.
-use core::cell::UnsafeCell;
 use core::{mem, ptr};
 use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
@@ -23,58 +22,6 @@ pub fn map_in_place_2<T, U, F: FnOnce(U, T) -> T>((k, v): (U, &mut T), f: F) {
         // If we made it here, the calling thread could have already have panicked, in which case
         // We know that the closure did not panic, so don't bother checking.
         std::mem::forget(promote_panic_to_abort);
-    }
-}
-
-/// A simple wrapper around `T`
-///
-/// This is to prevent UB when using `HashMap::get_key_value`, because
-/// `HashMap` doesn't expose an api to get the key and value, where
-/// the value is a `&mut T`.
-///
-/// See [#10](https://github.com/xacrimon/dashmap/issues/10) for details
-///
-/// This type is meant to be an implementation detail, but must be exposed due to the `Dashmap::shards`
-#[repr(transparent)]
-pub struct SharedValue<T> {
-    value: UnsafeCell<T>,
-}
-
-impl<T: Clone> Clone for SharedValue<T> {
-    fn clone(&self) -> Self {
-        let inner = self.get().clone();
-
-        Self {
-            value: UnsafeCell::new(inner),
-        }
-    }
-}
-
-unsafe impl<T: Send> Send for SharedValue<T> {}
-
-unsafe impl<T: Sync> Sync for SharedValue<T> {}
-
-impl<T> SharedValue<T> {
-    /// Create a new `SharedValue<T>`
-    pub const fn new(value: T) -> Self {
-        Self {
-            value: UnsafeCell::new(value),
-        }
-    }
-
-    /// Get a shared reference to `T`
-    pub fn get(&self) -> &T {
-        unsafe { &*self.value.get() }
-    }
-
-    /// Get an unique reference to `T`
-    pub fn get_mut(&mut self) -> &mut T {
-        unsafe { &mut *self.value.get() }
-    }
-
-    /// Unwraps the value
-    pub fn into_inner(self) -> T {
-        self.value.into_inner()
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -65,6 +65,10 @@ impl<'a, R: RawRwLock> Drop for RwLockWriteGuardDetached<'a, R> {
 
 impl<'a, R: RawRwLock> RwLockReadGuardDetached<'a, R> {
     /// Separates the data from the [`RwLockReadGuard`]
+    ///
+    /// # Safety
+    ///
+    /// The data must not outlive the detached guard
     pub(crate) unsafe fn detach_from<T>(guard: RwLockReadGuard<'a, R, T>) -> (Self, &'a T) {
         let rwlock = RwLockReadGuard::rwlock(&ManuallyDrop::new(guard));
 
@@ -81,6 +85,10 @@ impl<'a, R: RawRwLock> RwLockReadGuardDetached<'a, R> {
 
 impl<'a, R: RawRwLock> RwLockWriteGuardDetached<'a, R> {
     /// Separates the data from the [`RwLockWriteGuard`]
+    ///
+    /// # Safety
+    ///
+    /// The data must not outlive the detached guard
     pub(crate) unsafe fn detach_from<T>(guard: RwLockWriteGuard<'a, R, T>) -> (Self, &'a mut T) {
         let rwlock = RwLockWriteGuard::rwlock(&ManuallyDrop::new(guard));
 
@@ -96,8 +104,11 @@ impl<'a, R: RawRwLock> RwLockWriteGuardDetached<'a, R> {
 }
 
 impl<'a, R: RawRwLockDowngrade> RwLockWriteGuardDetached<'a, R> {
+    /// # Safety
+    ///
+    /// The associated data must not mut mutated after downgrading
     pub(crate) unsafe fn downgrade(self) -> RwLockReadGuardDetached<'a, R> {
-        self.lock.downgrade();
+        unsafe { self.lock.downgrade() }
         RwLockReadGuardDetached {
             lock: self.lock,
             _marker: self._marker,


### PR DESCRIPTION
hashbrown removed the RawTable API, requiring dashmap to use `HashTable` instead. This was the API I wanted dashmap 6 to use initially as the shards being RawTable means unsafe is often necessary.

Due to needing some more RwLock mapping support when it comes to HashTable iterators and such, I designed the `RwLockReadGuardDetached` which cleans up a fair amount of pointer shenanigans around the codebase.

In the process, I also decided to remove all the `unsafe impl Send` and make the RawRwLock guard be Send instead, as it seemingly is intended to be.

`miri` with both stacked and tree borrows seem happy still, and there's a lot less unsafe in the process.