### PR TITLE
Add `DashMap::extend_non_mut` and `DashSet::extend_non_mut`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -566,6 +566,27 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
         self._iter_mut()
     }
 
+    /// Extends the map with the key-value pairs from an iterator.
+    ///
+    /// A replacement of [`DashMap::extend`](DashMap::extend) without the need of a mutable reference to the map.
+    ///
+    /// **Locking behaviour:** May deadlock if called when holding any sort of reference into the map.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dashmap::DashMap;
+    ///
+    /// let map = DashMap::new();
+    /// map.extend_non_mut(vec![(1, 2), (3, 4)]);
+    /// assert_eq!(map.len(), 2);
+    /// ```
+    pub fn extend_non_mut(&self, it: impl IntoIterator<Item = (K, V)>) {
+        for (k, v) in it {
+            self.insert(k, v);
+        }
+    }
+
     /// Get an immutable reference to an entry in the map
     ///
     /// **Locking behaviour:** May deadlock if called when holding a mutable reference into the map.
@@ -1329,6 +1350,9 @@ impl<'a, K: Eq + Hash, V, S: BuildHasher + Clone> IntoIterator for &'a DashMap<K
 }
 
 impl<K: Eq + Hash, V, S: BuildHasher + Clone> Extend<(K, V)> for DashMap<K, V, S> {
+    /// Extends the map with the key-value pairs from an iterator.
+    ///
+    /// If you don't have a mutable reference to the map, you can use [`extend_non_mut`](DashMap::extend_non_mut) instead.
     fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, intoiter: I) {
         for pair in intoiter.into_iter() {
             self.insert(pair.0, pair.1);

--- a/src/set.rs
+++ b/src/set.rs
@@ -254,6 +254,25 @@ impl<'a, K: 'a + Eq + Hash, S: BuildHasher + Clone> DashSet<K, S> {
         self.inner.remove_if(key, |k, _| f(k)).map(|(k, _)| k)
     }
 
+    /// Extends the set with the contents of an iterator.
+    ///
+    /// A replacement of [`DashSet::extend`](DashSet::extend) without the need of a mutable reference to the map.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dashmap::DashSet;
+    ///
+    /// let numbers = DashSet::new();
+    /// numbers.extend_non_mut(vec![1, 2]);
+    /// assert_eq!(numbers.len(), 2);
+    /// ```
+    pub fn extend_non_mut(&self, it: impl IntoIterator<Item = K>) {
+        for k in it {
+            self.insert(k);
+        }
+    }
+
     /// Creates an iterator over a DashMap yielding immutable references.
     ///
     /// # Examples
@@ -398,6 +417,9 @@ impl<K: Eq + Hash, S: BuildHasher + Clone> IntoIterator for DashSet<K, S> {
 }
 
 impl<K: Eq + Hash, S: BuildHasher + Clone> Extend<K> for DashSet<K, S> {
+    /// Extends the set with the contents of an iterator.
+    ///
+    /// If you don't have a mutable reference to the set, you can use [`extend_non_mut`](DashSet::extend_non_mut) instead.
     fn extend<T: IntoIterator<Item = K>>(&mut self, iter: T) {
         let iter = iter.into_iter().map(|k| (k, ()));
 


### PR DESCRIPTION
Fixes #281

`DashMap::extend` and `DashSet::extend` require a mutable reference because of the underlying Extend trait, which can be limiting. This PR adds `DashMap::extend_non_mut` and `DashSet::extend_non_mut`, allowing the same functionality with an immutable reference (`&self`) for improved flexibility.