### PR TITLE
remove SharedValue

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,15 +46,7 @@ use std::collections::hash_map::RandomState;
 pub use t::Map;
 use try_result::TryResult;
 
-cfg_if! {
-    if #[cfg(feature = "raw-api")] {
-        pub use util::SharedValue;
-    } else {
-        use util::SharedValue;
-    }
-}
-
-pub(crate) type HashMap<K, V> = hashbrown::raw::RawTable<(K, SharedValue<V>)>;
+pub(crate) type HashMap<K, V> = hashbrown::raw::RawTable<(K, V)>;
 
 // Temporary reimplementation of [`std::collections::TryReserveError`]
 // util [`std::collections::TryReserveError`] stabilises.
@@ -335,18 +327,17 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
             ///
             /// ```
             /// use dashmap::DashMap;
-            /// use dashmap::SharedValue;
             /// use std::hash::{Hash, Hasher, BuildHasher};
             ///
             /// let mut map = DashMap::<i32, &'static str>::new();
             /// let shard_ind = map.determine_map(&42);
             /// let mut factory = map.hasher().clone();
-            /// let hasher = |tuple: &(i32, SharedValue<&'static str>)| {
+            /// let hasher = |tuple: &(i32, &'static str)| {
             ///     let mut hasher = factory.build_hasher();
             ///     tuple.0.hash(&mut hasher);
             ///     hasher.finish()
             /// };
-            /// let data = (42, SharedValue::new("forty two"));
+            /// let data = (42, "forty two");
             /// let hash = hasher(&data);
             /// map.shards_mut()[shard_ind].get_mut().insert(hash, data, hasher);
             /// assert_eq!(*map.get(&42).unwrap(), "forty two");
@@ -969,7 +960,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
 
         if let Some(bucket) = shard.find(hash, |(k, _v)| key == k.borrow()) {
             let ((k, v), _) = unsafe { shard.remove(bucket) };
-            Some((k, v.into_inner()))
+            Some((k, v))
         } else {
             None
         }
@@ -988,9 +979,9 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
 
         if let Some(bucket) = shard.find(hash, |(k, _v)| key == k.borrow()) {
             let (k, v) = unsafe { bucket.as_ref() };
-            if f(k, v.get()) {
+            if f(k, v) {
                 let ((k, v), _) = unsafe { shard.remove(bucket) };
-                Some((k, v.into_inner()))
+                Some((k, v))
             } else {
                 None
             }
@@ -1012,9 +1003,9 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
 
         if let Some(bucket) = shard.find(hash, |(k, _v)| key == k.borrow()) {
             let (k, v) = unsafe { bucket.as_mut() };
-            if f(k, v.get_mut()) {
+            if f(k, v) {
                 let ((k, v), _) = unsafe { shard.remove(bucket) };
-                Some((k, v.into_inner()))
+                Some((k, v))
             } else {
                 None
             }
@@ -1045,7 +1036,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
         if let Some(bucket) = shard.find(hash, |(k, _v)| key == k.borrow()) {
             unsafe {
                 let (k, v) = bucket.as_ref();
-                Some(Ref::new(shard, k, v.as_ptr()))
+                Some(Ref::new(shard, k, v))
             }
         } else {
             None
@@ -1065,8 +1056,8 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
 
         if let Some(bucket) = shard.find(hash, |(k, _v)| key == k.borrow()) {
             unsafe {
-                let (k, v) = bucket.as_ref();
-                Some(RefMut::new(shard, k, v.as_ptr()))
+                let (k, v) = bucket.as_mut();
+                Some(RefMut::new(shard, k, v))
             }
         } else {
             None
@@ -1090,7 +1081,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
         if let Some(bucket) = shard.find(hash, |(k, _v)| key == k.borrow()) {
             unsafe {
                 let (k, v) = bucket.as_ref();
-                TryResult::Present(Ref::new(shard, k, v.as_ptr()))
+                TryResult::Present(Ref::new(shard, k, v))
             }
         } else {
             TryResult::Absent
@@ -1113,8 +1104,8 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
 
         if let Some(bucket) = shard.find(hash, |(k, _v)| key == k.borrow()) {
             unsafe {
-                let (k, v) = bucket.as_ref();
-                TryResult::Present(RefMut::new(shard, k, v.as_ptr()))
+                let (k, v) = bucket.as_mut();
+                TryResult::Present(RefMut::new(shard, k, v))
             }
         } else {
             TryResult::Absent
@@ -1140,7 +1131,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
                 // Here we only use `iter` as a temporary, preventing use-after-free
                 for bucket in shard.iter() {
                     let (k, v) = bucket.as_mut();
-                    if !f(&*k, v.get_mut()) {
+                    if !f(&*k, v) {
                         shard.erase(bucket);
                     }
                 }
@@ -1366,7 +1357,7 @@ where
                 let entry_size_iter = iter.map(|bucket| {
                     // Safety: The iterator returns buckets with valid pointers to entries
                     let (key, value) = unsafe { bucket.as_ref() };
-                    key.extra_size() + value.get().extra_size()
+                    key.extra_size() + value.extra_size()
                 });
 
                 core::mem::size_of::<CachePadded<RwLock<HashMap<K, V>>>>()

--- a/src/rayon/map.rs
+++ b/src/rayon/map.rs
@@ -95,13 +95,7 @@ where
     {
         Vec::from(self.shards)
             .into_par_iter()
-            .flat_map_iter(|shard| {
-                shard
-                    .into_inner()
-                    .into_inner()
-                    .into_iter()
-                    .map(|(k, v)| (k, v.into_inner()))
-            })
+            .flat_map_iter(|shard| shard.into_inner().into_inner().into_iter())
             .drive_unindexed(consumer)
     }
 }
@@ -145,7 +139,7 @@ where
                 guard.iter().map(move |b| {
                     let guard = Arc::clone(&guard);
                     let (k, v) = b.as_ref();
-                    RefMulti::new(guard, k, v.get())
+                    RefMulti::new(guard, k, v)
                 })
             })
             .drive_unindexed(consumer)
@@ -203,7 +197,7 @@ where
                 guard.iter().map(move |b| {
                     let guard = Arc::clone(&guard);
                     let (k, v) = b.as_mut();
-                    RefMutMulti::new(guard, k, v.get_mut())
+                    RefMutMulti::new(guard, k, v)
                 })
             })
             .drive_unindexed(consumer)

--- a/src/read_only.rs
+++ b/src/read_only.rs
@@ -88,7 +88,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> ReadOnlyView<K, V, S>
 
         shard.find(hash, |(k, _v)| key == k.borrow()).map(|b| {
             let (k, v) = unsafe { b.as_ref() };
-            (k, v.get())
+            (k, v)
         })
     }
 
@@ -100,7 +100,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> ReadOnlyView<K, V, S>
                 .flat_map(|shard| shard.iter())
                 .map(|b| {
                     let (k, v) = b.as_ref();
-                    (k, v.get())
+                    (k, v)
                 })
         }
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,5 @@
 //! This module is full of hackery and dark magic.
 //! Either spend a day fixing it and quietly submit a PR or don't mention it to anybody.
-use core::cell::UnsafeCell;
 use core::{mem, ptr};
 
 pub const fn ptr_size_bits() -> usize {
@@ -19,63 +18,6 @@ pub fn map_in_place_2<T, U, F: FnOnce(U, T) -> T>((k, v): (U, &mut T), f: F) {
         // If we made it here, the calling thread could have already have panicked, in which case
         // We know that the closure did not panic, so don't bother checking.
         std::mem::forget(promote_panic_to_abort);
-    }
-}
-
-/// A simple wrapper around `T`
-///
-/// This is to prevent UB when using `HashMap::get_key_value`, because
-/// `HashMap` doesn't expose an api to get the key and value, where
-/// the value is a `&mut T`.
-///
-/// See [#10](https://github.com/xacrimon/dashmap/issues/10) for details
-///
-/// This type is meant to be an implementation detail, but must be exposed due to the `Dashmap::shards`
-#[repr(transparent)]
-pub struct SharedValue<T> {
-    value: UnsafeCell<T>,
-}
-
-impl<T: Clone> Clone for SharedValue<T> {
-    fn clone(&self) -> Self {
-        let inner = self.get().clone();
-
-        Self {
-            value: UnsafeCell::new(inner),
-        }
-    }
-}
-
-unsafe impl<T: Send> Send for SharedValue<T> {}
-
-unsafe impl<T: Sync> Sync for SharedValue<T> {}
-
-impl<T> SharedValue<T> {
-    /// Create a new `SharedValue<T>`
-    pub const fn new(value: T) -> Self {
-        Self {
-            value: UnsafeCell::new(value),
-        }
-    }
-
-    /// Get a shared reference to `T`
-    pub fn get(&self) -> &T {
-        unsafe { &*self.value.get() }
-    }
-
-    /// Get an unique reference to `T`
-    pub fn get_mut(&mut self) -> &mut T {
-        unsafe { &mut *self.value.get() }
-    }
-
-    /// Unwraps the value
-    pub fn into_inner(self) -> T {
-        self.value.into_inner()
-    }
-
-    /// Get a mutable raw pointer to the underlying value
-    pub(crate) fn as_ptr(&self) -> *mut T {
-        self.value.get()
     }
 }
 


### PR DESCRIPTION
This is a breaking change to the raw-api feature.

I looked at the history of SharedValue. It was introduced to fix #10 to circumvent some pointer shenanigans. 

I looked through the code and couldn't find anything relevant anymore. All pointers in a RefMut are derived from `&mut V` and never convert through `&V`, thus we never have a case where `&V -> &mut V`.

I have tested with miri too, which would definitely complain if this is violated.

(this is a pre-requisite for some later changes I wish to make, see #314)