### PR TITLE
Remove large amounts of unsafe from Refs via 'detached' lock guards

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -69,22 +69,6 @@ impl<K: Eq + Hash, V, S: BuildHasher + Clone> Iterator for OwningIter<K, V, S> {
     }
 }
 
-unsafe impl<K, V, S> Send for OwningIter<K, V, S>
-where
-    K: Eq + Hash + Send,
-    V: Send,
-    S: BuildHasher + Clone + Send,
-{
-}
-
-unsafe impl<K, V, S> Sync for OwningIter<K, V, S>
-where
-    K: Eq + Hash + Sync,
-    V: Sync,
-    S: BuildHasher + Clone + Sync,
-{
-}
-
 type GuardIter<'a, K, V> = (
     Arc<RwLockReadGuardDetached<'a>>,
     hashbrown::raw::RawIter<(K, V)>,
@@ -117,24 +101,6 @@ impl<'i, K: Clone + Hash + Eq, V: Clone, S: Clone + BuildHasher> Clone for Iter<
     fn clone(&self) -> Self {
         Iter::new(self.map)
     }
-}
-
-unsafe impl<'a, 'i, K, V, S, M> Send for Iter<'i, K, V, S, M>
-where
-    K: 'a + Eq + Hash + Send,
-    V: 'a + Send,
-    S: 'a + BuildHasher + Clone,
-    M: Map<'a, K, V, S>,
-{
-}
-
-unsafe impl<'a, 'i, K, V, S, M> Sync for Iter<'i, K, V, S, M>
-where
-    K: 'a + Eq + Hash + Sync,
-    V: 'a + Sync,
-    S: 'a + BuildHasher + Clone,
-    M: Map<'a, K, V, S>,
-{
 }
 
 impl<'a, K: Eq + Hash + 'a, V: 'a, S: 'a + BuildHasher + Clone, M: Map<'a, K, V, S>>
@@ -202,24 +168,6 @@ pub struct IterMut<'a, K, V, S = RandomState, M = DashMap<K, V, S>> {
     shard_i: usize,
     current: Option<GuardIterMut<'a, K, V>>,
     marker: PhantomData<S>,
-}
-
-unsafe impl<'a, 'i, K, V, S, M> Send for IterMut<'i, K, V, S, M>
-where
-    K: 'a + Eq + Hash + Send,
-    V: 'a + Send,
-    S: 'a + BuildHasher + Clone,
-    M: Map<'a, K, V, S>,
-{
-}
-
-unsafe impl<'a, 'i, K, V, S, M> Sync for IterMut<'i, K, V, S, M>
-where
-    K: 'a + Eq + Hash + Sync,
-    V: 'a + Sync,
-    S: 'a + BuildHasher + Clone,
-    M: Map<'a, K, V, S>,
-{
 }
 
 impl<'a, K: Eq + Hash + 'a, V: 'a, S: 'a + BuildHasher + Clone, M: Map<'a, K, V, S>>

--- a/src/iter_set.rs
+++ b/src/iter_set.rs
@@ -20,38 +20,8 @@ impl<K: Eq + Hash, S: BuildHasher + Clone> Iterator for OwningIter<K, S> {
     }
 }
 
-unsafe impl<K, S> Send for OwningIter<K, S>
-where
-    K: Eq + Hash + Send,
-    S: BuildHasher + Clone + Send,
-{
-}
-
-unsafe impl<K, S> Sync for OwningIter<K, S>
-where
-    K: Eq + Hash + Sync,
-    S: BuildHasher + Clone + Sync,
-{
-}
-
 pub struct Iter<'a, K, S, M> {
     inner: crate::iter::Iter<'a, K, (), S, M>,
-}
-
-unsafe impl<'a, 'i, K, S, M> Send for Iter<'i, K, S, M>
-where
-    K: 'a + Eq + Hash + Send,
-    S: 'a + BuildHasher + Clone,
-    M: Map<'a, K, (), S>,
-{
-}
-
-unsafe impl<'a, 'i, K, S, M> Sync for Iter<'i, K, S, M>
-where
-    K: 'a + Eq + Hash + Sync,
-    S: 'a + BuildHasher + Clone,
-    M: Map<'a, K, (), S>,
-{
 }
 
 impl<'a, K: Eq + Hash + 'a, S: 'a + BuildHasher + Clone, M: Map<'a, K, (), S>> Iter<'a, K, S, M> {

--- a/src/iter_set.rs
+++ b/src/iter_set.rs
@@ -54,13 +54,13 @@ where
 {
 }
 
-impl<'a, K: Eq + Hash, S: 'a + BuildHasher + Clone, M: Map<'a, K, (), S>> Iter<'a, K, S, M> {
+impl<'a, K: Eq + Hash + 'a, S: 'a + BuildHasher + Clone, M: Map<'a, K, (), S>> Iter<'a, K, S, M> {
     pub(crate) fn new(inner: crate::iter::Iter<'a, K, (), S, M>) -> Self {
         Self { inner }
     }
 }
 
-impl<'a, K: Eq + Hash, S: 'a + BuildHasher + Clone, M: Map<'a, K, (), S>> Iterator
+impl<'a, K: Eq + Hash + 'a, S: 'a + BuildHasher + Clone, M: Map<'a, K, (), S>> Iterator
     for Iter<'a, K, S, M>
 {
     type Item = RefMulti<'a, K>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ use core::iter::FromIterator;
 use core::ops::{BitAnd, BitOr, Shl, Shr, Sub};
 use crossbeam_utils::CachePadded;
 use iter::{Iter, IterMut, OwningIter};
+use lock::{RwLockReadGuardDetached, RwLockWriteGuardDetached};
 pub use mapref::entry::{Entry, OccupiedEntry, VacantEntry};
 use mapref::multiple::RefMulti;
 use mapref::one::{Ref, RefMut};
@@ -1032,11 +1033,13 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
         let idx = self.determine_shard(hash as usize);
 
         let shard = unsafe { self._yield_read_shard(idx) };
+        // SAFETY: The data will not outlive the guard, since we pass the guard to `Ref`.
+        let (guard, shard) = unsafe { RwLockReadGuardDetached::detach_from(shard) };
 
         if let Some(bucket) = shard.find(hash, |(k, _v)| key == k.borrow()) {
             unsafe {
                 let (k, v) = bucket.as_ref();
-                Some(Ref::new(shard, k, v))
+                Some(Ref::new(guard, k, v))
             }
         } else {
             None
@@ -1053,11 +1056,13 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
         let idx = self.determine_shard(hash as usize);
 
         let shard = unsafe { self._yield_write_shard(idx) };
+        // SAFETY: The data will not outlive the guard, since we pass the guard to `RefMut`.
+        let (guard, shard) = unsafe { RwLockWriteGuardDetached::detach_from(shard) };
 
         if let Some(bucket) = shard.find(hash, |(k, _v)| key == k.borrow()) {
             unsafe {
                 let (k, v) = bucket.as_mut();
-                Some(RefMut::new(shard, k, v))
+                Some(RefMut::new(guard, k, v))
             }
         } else {
             None
@@ -1077,11 +1082,13 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
             Some(shard) => shard,
             None => return TryResult::Locked,
         };
+        // SAFETY: The data will not outlive the guard, since we pass the guard to `Ref`.
+        let (guard, shard) = unsafe { RwLockReadGuardDetached::detach_from(shard) };
 
         if let Some(bucket) = shard.find(hash, |(k, _v)| key == k.borrow()) {
             unsafe {
                 let (k, v) = bucket.as_ref();
-                TryResult::Present(Ref::new(shard, k, v))
+                TryResult::Present(Ref::new(guard, k, v))
             }
         } else {
             TryResult::Absent
@@ -1101,11 +1108,13 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
             Some(shard) => shard,
             None => return TryResult::Locked,
         };
+        // SAFETY: The data will not outlive the guard, since we pass the guard to `RefMut`.
+        let (guard, shard) = unsafe { RwLockWriteGuardDetached::detach_from(shard) };
 
         if let Some(bucket) = shard.find(hash, |(k, _v)| key == k.borrow()) {
             unsafe {
                 let (k, v) = bucket.as_mut();
-                TryResult::Present(RefMut::new(shard, k, v))
+                TryResult::Present(RefMut::new(guard, k, v))
             }
         } else {
             TryResult::Absent
@@ -1178,7 +1187,9 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
 
         let idx = self.determine_shard(hash as usize);
 
-        let mut shard = unsafe { self._yield_write_shard(idx) };
+        let shard = unsafe { self._yield_write_shard(idx) };
+        // SAFETY: The data will not outlive the guard, since we pass the guard to `Entry`.
+        let (guard, shard) = unsafe { RwLockWriteGuardDetached::detach_from(shard) };
 
         match shard.find_or_find_insert_slot(
             hash,
@@ -1189,8 +1200,8 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
                 hasher.finish()
             },
         ) {
-            Ok(elem) => Entry::Occupied(unsafe { OccupiedEntry::new(shard, key, elem) }),
-            Err(slot) => Entry::Vacant(unsafe { VacantEntry::new(shard, key, hash, slot) }),
+            Ok(elem) => Entry::Occupied(unsafe { OccupiedEntry::new(guard, key, shard, elem) }),
+            Err(slot) => Entry::Vacant(unsafe { VacantEntry::new(guard, key, hash, shard, slot) }),
         }
     }
 
@@ -1199,10 +1210,12 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
 
         let idx = self.determine_shard(hash as usize);
 
-        let mut shard = match unsafe { self._try_yield_write_shard(idx) } {
+        let shard = match unsafe { self._try_yield_write_shard(idx) } {
             Some(shard) => shard,
             None => return None,
         };
+        // SAFETY: The data will not outlive the guard, since we pass the guard to `Entry`.
+        let (guard, shard) = unsafe { RwLockWriteGuardDetached::detach_from(shard) };
 
         match shard.find_or_find_insert_slot(
             hash,
@@ -1214,10 +1227,10 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
             },
         ) {
             Ok(elem) => Some(Entry::Occupied(unsafe {
-                OccupiedEntry::new(shard, key, elem)
+                OccupiedEntry::new(guard, key, shard, elem)
             })),
             Err(slot) => Some(Entry::Vacant(unsafe {
-                VacantEntry::new(shard, key, hash, slot)
+                VacantEntry::new(guard, key, hash, shard, slot)
             })),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,15 +46,7 @@ use std::collections::hash_map::RandomState;
 pub use t::Map;
 use try_result::TryResult;
 
-cfg_if! {
-    if #[cfg(feature = "raw-api")] {
-        pub use util::SharedValue;
-    } else {
-        use util::SharedValue;
-    }
-}
-
-pub(crate) type HashMap<K, V> = hashbrown::raw::RawTable<(K, SharedValue<V>)>;
+pub(crate) type HashMap<K, V> = hashbrown::raw::RawTable<(K, V)>;
 
 // Temporary reimplementation of [`std::collections::TryReserveError`]
 // util [`std::collections::TryReserveError`] stabilises.
@@ -335,18 +327,17 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
             ///
             /// ```
             /// use dashmap::DashMap;
-            /// use dashmap::SharedValue;
             /// use std::hash::{Hash, Hasher, BuildHasher};
             ///
             /// let mut map = DashMap::<i32, &'static str>::new();
             /// let shard_ind = map.determine_map(&42);
             /// let mut factory = map.hasher().clone();
-            /// let hasher = |tuple: &(i32, SharedValue<&'static str>)| {
+            /// let hasher = |tuple: &(i32, &'static str)| {
             ///     let mut hasher = factory.build_hasher();
             ///     tuple.0.hash(&mut hasher);
             ///     hasher.finish()
             /// };
-            /// let data = (42, SharedValue::new("forty two"));
+            /// let data = (42, "forty two");
             /// let hash = hasher(&data);
             /// map.shards_mut()[shard_ind].get_mut().insert(hash, data, hasher);
             /// assert_eq!(*map.get(&42).unwrap(), "forty two");
@@ -969,7 +960,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
 
         if let Some(bucket) = shard.find(hash, |(k, _v)| key == k.borrow()) {
             let ((k, v), _) = unsafe { shard.remove(bucket) };
-            Some((k, v.into_inner()))
+            Some((k, v))
         } else {
             None
         }
@@ -988,9 +979,9 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
 
         if let Some(bucket) = shard.find(hash, |(k, _v)| key == k.borrow()) {
             let (k, v) = unsafe { bucket.as_ref() };
-            if f(k, v.get()) {
+            if f(k, v) {
                 let ((k, v), _) = unsafe { shard.remove(bucket) };
-                Some((k, v.into_inner()))
+                Some((k, v))
             } else {
                 None
             }
@@ -1012,9 +1003,9 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
 
         if let Some(bucket) = shard.find(hash, |(k, _v)| key == k.borrow()) {
             let (k, v) = unsafe { bucket.as_mut() };
-            if f(k, v.get_mut()) {
+            if f(k, v) {
                 let ((k, v), _) = unsafe { shard.remove(bucket) };
-                Some((k, v.into_inner()))
+                Some((k, v))
             } else {
                 None
             }
@@ -1045,7 +1036,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
         if let Some(bucket) = shard.find(hash, |(k, _v)| key == k.borrow()) {
             unsafe {
                 let (k, v) = bucket.as_ref();
-                Some(Ref::new(shard, k, v.as_ptr()))
+                Some(Ref::new(shard, k, v))
             }
         } else {
             None
@@ -1065,8 +1056,8 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
 
         if let Some(bucket) = shard.find(hash, |(k, _v)| key == k.borrow()) {
             unsafe {
-                let (k, v) = bucket.as_ref();
-                Some(RefMut::new(shard, k, v.as_ptr()))
+                let (k, v) = bucket.as_mut();
+                Some(RefMut::new(shard, k, v))
             }
         } else {
             None
@@ -1090,7 +1081,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
         if let Some(bucket) = shard.find(hash, |(k, _v)| key == k.borrow()) {
             unsafe {
                 let (k, v) = bucket.as_ref();
-                TryResult::Present(Ref::new(shard, k, v.as_ptr()))
+                TryResult::Present(Ref::new(shard, k, v))
             }
         } else {
             TryResult::Absent
@@ -1113,8 +1104,8 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
 
         if let Some(bucket) = shard.find(hash, |(k, _v)| key == k.borrow()) {
             unsafe {
-                let (k, v) = bucket.as_ref();
-                TryResult::Present(RefMut::new(shard, k, v.as_ptr()))
+                let (k, v) = bucket.as_mut();
+                TryResult::Present(RefMut::new(shard, k, v))
             }
         } else {
             TryResult::Absent
@@ -1140,7 +1131,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> Map<'a, K, V, S>
                 // Here we only use `iter` as a temporary, preventing use-after-free
                 for bucket in shard.iter() {
                     let (k, v) = bucket.as_mut();
-                    if !f(&*k, v.get_mut()) {
+                    if !f(&*k, v) {
                         shard.erase(bucket);
                     }
                 }
@@ -1366,7 +1357,7 @@ where
                 let entry_size_iter = iter.map(|bucket| {
                     // Safety: The iterator returns buckets with valid pointers to entries
                     let (key, value) = unsafe { bucket.as_ref() };
-                    key.extra_size() + value.get().extra_size()
+                    key.extra_size() + value.extra_size()
                 });
 
                 core::mem::size_of::<CachePadded<RwLock<HashMap<K, V>>>>()

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -4,6 +4,8 @@ use parking_lot_core::{ParkToken, SpinWait, UnparkToken};
 pub type RwLock<T> = lock_api::RwLock<RawRwLock, T>;
 pub type RwLockReadGuard<'a, T> = lock_api::RwLockReadGuard<'a, RawRwLock, T>;
 pub type RwLockWriteGuard<'a, T> = lock_api::RwLockWriteGuard<'a, RawRwLock, T>;
+pub type RwLockReadGuardDetached<'a> = crate::util::RwLockReadGuardDetached<'a, RawRwLock>;
+pub type RwLockWriteGuardDetached<'a> = crate::util::RwLockWriteGuardDetached<'a, RawRwLock>;
 
 const READERS_PARKED: usize = 0b0001;
 const WRITERS_PARKED: usize = 0b0010;

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -22,7 +22,7 @@ unsafe impl lock_api::RawRwLock for RawRwLock {
         state: AtomicUsize::new(0),
     };
 
-    type GuardMarker = lock_api::GuardNoSend;
+    type GuardMarker = lock_api::GuardSend;
 
     #[inline]
     fn try_lock_exclusive(&self) -> bool {

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -4,8 +4,8 @@ use parking_lot_core::{ParkToken, SpinWait, UnparkToken};
 pub type RwLock<T> = lock_api::RwLock<RawRwLock, T>;
 pub type RwLockReadGuard<'a, T> = lock_api::RwLockReadGuard<'a, RawRwLock, T>;
 pub type RwLockWriteGuard<'a, T> = lock_api::RwLockWriteGuard<'a, RawRwLock, T>;
-pub type RwLockReadGuardDetached<'a> = crate::util::RwLockReadGuardDetached<'a, RawRwLock>;
-pub type RwLockWriteGuardDetached<'a> = crate::util::RwLockWriteGuardDetached<'a, RawRwLock>;
+pub(crate) type RwLockReadGuardDetached<'a> = crate::util::RwLockReadGuardDetached<'a, RawRwLock>;
+pub(crate) type RwLockWriteGuardDetached<'a> = crate::util::RwLockWriteGuardDetached<'a, RawRwLock>;
 
 const READERS_PARKED: usize = 0b0001;
 const WRITERS_PARKED: usize = 0b0010;

--- a/src/mapref/entry.rs
+++ b/src/mapref/entry.rs
@@ -118,9 +118,6 @@ pub struct VacantEntry<'a, K, V> {
     slot: hashbrown::raw::InsertSlot,
 }
 
-unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Send for VacantEntry<'a, K, V> {}
-unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Sync for VacantEntry<'a, K, V> {}
-
 impl<'a, K: Eq + Hash, V> VacantEntry<'a, K, V> {
     pub(crate) unsafe fn new(
         shard: RwLockWriteGuardDetached<'a>,
@@ -179,9 +176,6 @@ pub struct OccupiedEntry<'a, K, V> {
     bucket: hashbrown::raw::Bucket<(K, V)>,
     key: K,
 }
-
-unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Send for OccupiedEntry<'a, K, V> {}
-unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Sync for OccupiedEntry<'a, K, V> {}
 
 impl<'a, K: Eq + Hash, V> OccupiedEntry<'a, K, V> {
     pub(crate) unsafe fn new(

--- a/src/mapref/multiple.rs
+++ b/src/mapref/multiple.rs
@@ -9,9 +9,6 @@ pub struct RefMulti<'a, K, V> {
     v: &'a V,
 }
 
-unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Send for RefMulti<'a, K, V> {}
-unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Sync for RefMulti<'a, K, V> {}
-
 impl<'a, K: Eq + Hash, V> RefMulti<'a, K, V> {
     pub(crate) unsafe fn new(guard: Arc<RwLockReadGuardDetached<'a>>, k: &'a K, v: &'a V) -> Self {
         Self {
@@ -47,9 +44,6 @@ pub struct RefMutMulti<'a, K, V> {
     k: &'a K,
     v: &'a mut V,
 }
-
-unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Send for RefMutMulti<'a, K, V> {}
-unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Sync for RefMutMulti<'a, K, V> {}
 
 impl<'a, K: Eq + Hash, V> RefMutMulti<'a, K, V> {
     pub(crate) unsafe fn new(

--- a/src/mapref/multiple.rs
+++ b/src/mapref/multiple.rs
@@ -1,24 +1,19 @@
-use crate::lock::{RwLockReadGuard, RwLockWriteGuard};
-use crate::HashMap;
+use crate::lock::{RwLockReadGuardDetached, RwLockWriteGuardDetached};
 use core::hash::Hash;
 use core::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
 pub struct RefMulti<'a, K, V> {
-    _guard: Arc<RwLockReadGuard<'a, HashMap<K, V>>>,
-    k: *const K,
-    v: *const V,
+    _guard: Arc<RwLockReadGuardDetached<'a>>,
+    k: &'a K,
+    v: &'a V,
 }
 
 unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Send for RefMulti<'a, K, V> {}
 unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Sync for RefMulti<'a, K, V> {}
 
 impl<'a, K: Eq + Hash, V> RefMulti<'a, K, V> {
-    pub(crate) unsafe fn new(
-        guard: Arc<RwLockReadGuard<'a, HashMap<K, V>>>,
-        k: *const K,
-        v: *const V,
-    ) -> Self {
+    pub(crate) unsafe fn new(guard: Arc<RwLockReadGuardDetached<'a>>, k: &'a K, v: &'a V) -> Self {
         Self {
             _guard: guard,
             k,
@@ -35,7 +30,7 @@ impl<'a, K: Eq + Hash, V> RefMulti<'a, K, V> {
     }
 
     pub fn pair(&self) -> (&K, &V) {
-        unsafe { (&*self.k, &*self.v) }
+        (&*self.k, &*self.v)
     }
 }
 
@@ -48,9 +43,9 @@ impl<'a, K: Eq + Hash, V> Deref for RefMulti<'a, K, V> {
 }
 
 pub struct RefMutMulti<'a, K, V> {
-    _guard: Arc<RwLockWriteGuard<'a, HashMap<K, V>>>,
-    k: *const K,
-    v: *mut V,
+    _guard: Arc<RwLockWriteGuardDetached<'a>>,
+    k: &'a K,
+    v: &'a mut V,
 }
 
 unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Send for RefMutMulti<'a, K, V> {}
@@ -58,9 +53,9 @@ unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Sync for RefMutMulti<'a, K, V> {}
 
 impl<'a, K: Eq + Hash, V> RefMutMulti<'a, K, V> {
     pub(crate) unsafe fn new(
-        guard: Arc<RwLockWriteGuard<'a, HashMap<K, V>>>,
-        k: *const K,
-        v: *mut V,
+        guard: Arc<RwLockWriteGuardDetached<'a>>,
+        k: &'a K,
+        v: &'a mut V,
     ) -> Self {
         Self {
             _guard: guard,
@@ -82,11 +77,11 @@ impl<'a, K: Eq + Hash, V> RefMutMulti<'a, K, V> {
     }
 
     pub fn pair(&self) -> (&K, &V) {
-        unsafe { (&*self.k, &*self.v) }
+        (&*self.k, &*self.v)
     }
 
     pub fn pair_mut(&mut self) -> (&K, &mut V) {
-        unsafe { (&*self.k, &mut *self.v) }
+        (&*self.k, &mut *self.v)
     }
 }
 

--- a/src/mapref/multiple.rs
+++ b/src/mapref/multiple.rs
@@ -27,7 +27,7 @@ impl<'a, K: Eq + Hash, V> RefMulti<'a, K, V> {
     }
 
     pub fn pair(&self) -> (&K, &V) {
-        (&*self.k, &*self.v)
+        (self.k, self.v)
     }
 }
 
@@ -71,11 +71,11 @@ impl<'a, K: Eq + Hash, V> RefMutMulti<'a, K, V> {
     }
 
     pub fn pair(&self) -> (&K, &V) {
-        (&*self.k, &*self.v)
+        (self.k, self.v)
     }
 
     pub fn pair_mut(&mut self) -> (&K, &mut V) {
-        (&*self.k, &mut *self.v)
+        (self.k, self.v)
     }
 }
 

--- a/src/mapref/one.rs
+++ b/src/mapref/one.rs
@@ -9,9 +9,6 @@ pub struct Ref<'a, K, V> {
     v: &'a V,
 }
 
-unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Send for Ref<'a, K, V> {}
-unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Sync for Ref<'a, K, V> {}
-
 impl<'a, K: Eq + Hash, V> Ref<'a, K, V> {
     pub(crate) unsafe fn new(guard: RwLockReadGuardDetached<'a>, k: &'a K, v: &'a V) -> Self {
         Self {
@@ -82,9 +79,6 @@ pub struct RefMut<'a, K, V> {
     k: &'a K,
     v: &'a mut V,
 }
-
-unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Send for RefMut<'a, K, V> {}
-unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Sync for RefMut<'a, K, V> {}
 
 impl<'a, K: Eq + Hash, V> RefMut<'a, K, V> {
     pub(crate) unsafe fn new(guard: RwLockWriteGuardDetached<'a>, k: &'a K, v: &'a mut V) -> Self {

--- a/src/mapref/one.rs
+++ b/src/mapref/one.rs
@@ -27,7 +27,7 @@ impl<'a, K: Eq + Hash, V> Ref<'a, K, V> {
     }
 
     pub fn pair(&self) -> (&K, &V) {
-        (&*self.k, &*self.v)
+        (self.k, self.v)
     }
 
     pub fn map<F, T>(self, f: F) -> MappedRef<'a, K, T>
@@ -37,7 +37,7 @@ impl<'a, K: Eq + Hash, V> Ref<'a, K, V> {
         MappedRef {
             _guard: self._guard,
             k: self.k,
-            v: f(&*self.v),
+            v: f(self.v),
         }
     }
 
@@ -45,7 +45,7 @@ impl<'a, K: Eq + Hash, V> Ref<'a, K, V> {
     where
         F: FnOnce(&V) -> Option<&T>,
     {
-        if let Some(v) = f(&*self.v) {
+        if let Some(v) = f(self.v) {
             Ok(MappedRef {
                 _guard: self._guard,
                 k: self.k,
@@ -98,11 +98,11 @@ impl<'a, K: Eq + Hash, V> RefMut<'a, K, V> {
     }
 
     pub fn pair(&self) -> (&K, &V) {
-        (&*self.k, &*self.v)
+        (self.k, self.v)
     }
 
     pub fn pair_mut(&mut self) -> (&K, &mut V) {
-        (&*self.k, &mut *self.v)
+        (self.k, self.v)
     }
 
     pub fn downgrade(self) -> Ref<'a, K, V> {
@@ -183,7 +183,7 @@ impl<'a, K: Eq + Hash, T> MappedRef<'a, K, T> {
     }
 
     pub fn pair(&self) -> (&K, &T) {
-        (&*self.k, &*self.v)
+        (self.k, self.v)
     }
 
     pub fn map<F, T2>(self, f: F) -> MappedRef<'a, K, T2>
@@ -193,7 +193,7 @@ impl<'a, K: Eq + Hash, T> MappedRef<'a, K, T> {
         MappedRef {
             _guard: self._guard,
             k: self.k,
-            v: f(&*self.v),
+            v: f(self.v),
         }
     }
 
@@ -201,7 +201,7 @@ impl<'a, K: Eq + Hash, T> MappedRef<'a, K, T> {
     where
         F: FnOnce(&T) -> Option<&T2>,
     {
-        let v = match f(&*self.v) {
+        let v = match f(self.v) {
             Some(v) => v,
             None => return Err(self),
         };
@@ -263,11 +263,11 @@ impl<'a, K: Eq + Hash, T> MappedRefMut<'a, K, T> {
     }
 
     pub fn pair(&self) -> (&K, &T) {
-        (&*self.k, &*self.v)
+        (self.k, self.v)
     }
 
     pub fn pair_mut(&mut self) -> (&K, &mut T) {
-        (&*self.k, &mut *self.v)
+        (self.k, self.v)
     }
 
     pub fn map<F, T2>(self, f: F) -> MappedRefMut<'a, K, T2>
@@ -277,7 +277,7 @@ impl<'a, K: Eq + Hash, T> MappedRefMut<'a, K, T> {
         MappedRefMut {
             _guard: self._guard,
             k: self.k,
-            v: f(&mut *self.v),
+            v: f(self.v),
         }
     }
 

--- a/src/mapref/one.rs
+++ b/src/mapref/one.rs
@@ -1,24 +1,19 @@
-use crate::lock::{RwLockReadGuard, RwLockWriteGuard};
-use crate::HashMap;
+use crate::lock::{RwLockReadGuardDetached, RwLockWriteGuardDetached};
 use core::hash::Hash;
 use core::ops::{Deref, DerefMut};
 use std::fmt::{Debug, Formatter};
 
 pub struct Ref<'a, K, V> {
-    _guard: RwLockReadGuard<'a, HashMap<K, V>>,
-    k: *const K,
-    v: *const V,
+    _guard: RwLockReadGuardDetached<'a>,
+    k: &'a K,
+    v: &'a V,
 }
 
 unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Send for Ref<'a, K, V> {}
 unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Sync for Ref<'a, K, V> {}
 
 impl<'a, K: Eq + Hash, V> Ref<'a, K, V> {
-    pub(crate) unsafe fn new(
-        guard: RwLockReadGuard<'a, HashMap<K, V>>,
-        k: *const K,
-        v: *const V,
-    ) -> Self {
+    pub(crate) unsafe fn new(guard: RwLockReadGuardDetached<'a>, k: &'a K, v: &'a V) -> Self {
         Self {
             _guard: guard,
             k,
@@ -35,25 +30,25 @@ impl<'a, K: Eq + Hash, V> Ref<'a, K, V> {
     }
 
     pub fn pair(&self) -> (&K, &V) {
-        unsafe { (&*self.k, &*self.v) }
+        (&*self.k, &*self.v)
     }
 
-    pub fn map<F, T>(self, f: F) -> MappedRef<'a, K, V, T>
+    pub fn map<F, T>(self, f: F) -> MappedRef<'a, K, T>
     where
         F: FnOnce(&V) -> &T,
     {
         MappedRef {
             _guard: self._guard,
             k: self.k,
-            v: f(unsafe { &*self.v }),
+            v: f(&*self.v),
         }
     }
 
-    pub fn try_map<F, T>(self, f: F) -> Result<MappedRef<'a, K, V, T>, Self>
+    pub fn try_map<F, T>(self, f: F) -> Result<MappedRef<'a, K, T>, Self>
     where
         F: FnOnce(&V) -> Option<&T>,
     {
-        if let Some(v) = f(unsafe { &*self.v }) {
+        if let Some(v) = f(&*self.v) {
             Ok(MappedRef {
                 _guard: self._guard,
                 k: self.k,
@@ -83,20 +78,16 @@ impl<'a, K: Eq + Hash, V> Deref for Ref<'a, K, V> {
 }
 
 pub struct RefMut<'a, K, V> {
-    guard: RwLockWriteGuard<'a, HashMap<K, V>>,
-    k: *const K,
-    v: *mut V,
+    guard: RwLockWriteGuardDetached<'a>,
+    k: &'a K,
+    v: &'a mut V,
 }
 
 unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Send for RefMut<'a, K, V> {}
 unsafe impl<'a, K: Eq + Hash + Sync, V: Sync> Sync for RefMut<'a, K, V> {}
 
 impl<'a, K: Eq + Hash, V> RefMut<'a, K, V> {
-    pub(crate) unsafe fn new(
-        guard: RwLockWriteGuard<'a, HashMap<K, V>>,
-        k: *const K,
-        v: *mut V,
-    ) -> Self {
+    pub(crate) unsafe fn new(guard: RwLockWriteGuardDetached<'a>, k: &'a K, v: &'a mut V) -> Self {
         Self { guard, k, v }
     }
 
@@ -113,29 +104,35 @@ impl<'a, K: Eq + Hash, V> RefMut<'a, K, V> {
     }
 
     pub fn pair(&self) -> (&K, &V) {
-        unsafe { (&*self.k, &*self.v) }
+        (&*self.k, &*self.v)
     }
 
     pub fn pair_mut(&mut self) -> (&K, &mut V) {
-        unsafe { (&*self.k, &mut *self.v) }
+        (&*self.k, &mut *self.v)
     }
 
     pub fn downgrade(self) -> Ref<'a, K, V> {
-        unsafe { Ref::new(RwLockWriteGuard::downgrade(self.guard), self.k, self.v) }
+        unsafe {
+            Ref::new(
+                RwLockWriteGuardDetached::downgrade(self.guard),
+                self.k,
+                self.v,
+            )
+        }
     }
 
-    pub fn map<F, T>(self, f: F) -> MappedRefMut<'a, K, V, T>
+    pub fn map<F, T>(self, f: F) -> MappedRefMut<'a, K, T>
     where
         F: FnOnce(&mut V) -> &mut T,
     {
         MappedRefMut {
             _guard: self.guard,
             k: self.k,
-            v: f(unsafe { &mut *self.v }),
+            v: f(&mut *self.v),
         }
     }
 
-    pub fn try_map<F, T>(self, f: F) -> Result<MappedRefMut<'a, K, V, T>, Self>
+    pub fn try_map<F, T>(self, f: F) -> Result<MappedRefMut<'a, K, T>, Self>
     where
         F: FnOnce(&mut V) -> Option<&mut T>,
     {
@@ -176,13 +173,13 @@ impl<'a, K: Eq + Hash, V> DerefMut for RefMut<'a, K, V> {
     }
 }
 
-pub struct MappedRef<'a, K, V, T> {
-    _guard: RwLockReadGuard<'a, HashMap<K, V>>,
-    k: *const K,
-    v: *const T,
+pub struct MappedRef<'a, K, T> {
+    _guard: RwLockReadGuardDetached<'a>,
+    k: &'a K,
+    v: &'a T,
 }
 
-impl<'a, K: Eq + Hash, V, T> MappedRef<'a, K, V, T> {
+impl<'a, K: Eq + Hash, T> MappedRef<'a, K, T> {
     pub fn key(&self) -> &K {
         self.pair().0
     }
@@ -192,25 +189,25 @@ impl<'a, K: Eq + Hash, V, T> MappedRef<'a, K, V, T> {
     }
 
     pub fn pair(&self) -> (&K, &T) {
-        unsafe { (&*self.k, &*self.v) }
+        (&*self.k, &*self.v)
     }
 
-    pub fn map<F, T2>(self, f: F) -> MappedRef<'a, K, V, T2>
+    pub fn map<F, T2>(self, f: F) -> MappedRef<'a, K, T2>
     where
         F: FnOnce(&T) -> &T2,
     {
         MappedRef {
             _guard: self._guard,
             k: self.k,
-            v: f(unsafe { &*self.v }),
+            v: f(&*self.v),
         }
     }
 
-    pub fn try_map<F, T2>(self, f: F) -> Result<MappedRef<'a, K, V, T2>, Self>
+    pub fn try_map<F, T2>(self, f: F) -> Result<MappedRef<'a, K, T2>, Self>
     where
         F: FnOnce(&T) -> Option<&T2>,
     {
-        let v = match f(unsafe { &*self.v }) {
+        let v = match f(&*self.v) {
             Some(v) => v,
             None => return Err(self),
         };
@@ -223,7 +220,7 @@ impl<'a, K: Eq + Hash, V, T> MappedRef<'a, K, V, T> {
     }
 }
 
-impl<'a, K: Eq + Hash + Debug, V, T: Debug> Debug for MappedRef<'a, K, V, T> {
+impl<'a, K: Eq + Hash + Debug, T: Debug> Debug for MappedRef<'a, K, T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MappedRef")
             .field("k", &self.k)
@@ -232,7 +229,7 @@ impl<'a, K: Eq + Hash + Debug, V, T: Debug> Debug for MappedRef<'a, K, V, T> {
     }
 }
 
-impl<'a, K: Eq + Hash, V, T> Deref for MappedRef<'a, K, V, T> {
+impl<'a, K: Eq + Hash, T> Deref for MappedRef<'a, K, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -240,27 +237,25 @@ impl<'a, K: Eq + Hash, V, T> Deref for MappedRef<'a, K, V, T> {
     }
 }
 
-impl<'a, K: Eq + Hash, V, T: std::fmt::Display> std::fmt::Display for MappedRef<'a, K, V, T> {
+impl<'a, K: Eq + Hash, T: std::fmt::Display> std::fmt::Display for MappedRef<'a, K, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self.value(), f)
     }
 }
 
-impl<'a, K: Eq + Hash, V, T: AsRef<TDeref>, TDeref: ?Sized> AsRef<TDeref>
-    for MappedRef<'a, K, V, T>
-{
+impl<'a, K: Eq + Hash, T: AsRef<TDeref>, TDeref: ?Sized> AsRef<TDeref> for MappedRef<'a, K, T> {
     fn as_ref(&self) -> &TDeref {
         self.value().as_ref()
     }
 }
 
-pub struct MappedRefMut<'a, K, V, T> {
-    _guard: RwLockWriteGuard<'a, HashMap<K, V>>,
-    k: *const K,
-    v: *mut T,
+pub struct MappedRefMut<'a, K, T> {
+    _guard: RwLockWriteGuardDetached<'a>,
+    k: &'a K,
+    v: &'a mut T,
 }
 
-impl<'a, K: Eq + Hash, V, T> MappedRefMut<'a, K, V, T> {
+impl<'a, K: Eq + Hash, T> MappedRefMut<'a, K, T> {
     pub fn key(&self) -> &K {
         self.pair().0
     }
@@ -274,25 +269,25 @@ impl<'a, K: Eq + Hash, V, T> MappedRefMut<'a, K, V, T> {
     }
 
     pub fn pair(&self) -> (&K, &T) {
-        unsafe { (&*self.k, &*self.v) }
+        (&*self.k, &*self.v)
     }
 
     pub fn pair_mut(&mut self) -> (&K, &mut T) {
-        unsafe { (&*self.k, &mut *self.v) }
+        (&*self.k, &mut *self.v)
     }
 
-    pub fn map<F, T2>(self, f: F) -> MappedRefMut<'a, K, V, T2>
+    pub fn map<F, T2>(self, f: F) -> MappedRefMut<'a, K, T2>
     where
         F: FnOnce(&mut T) -> &mut T2,
     {
         MappedRefMut {
             _guard: self._guard,
             k: self.k,
-            v: f(unsafe { &mut *self.v }),
+            v: f(&mut *self.v),
         }
     }
 
-    pub fn try_map<F, T2>(self, f: F) -> Result<MappedRefMut<'a, K, V, T2>, Self>
+    pub fn try_map<F, T2>(self, f: F) -> Result<MappedRefMut<'a, K, T2>, Self>
     where
         F: FnOnce(&mut T) -> Option<&mut T2>,
     {
@@ -310,7 +305,7 @@ impl<'a, K: Eq + Hash, V, T> MappedRefMut<'a, K, V, T> {
     }
 }
 
-impl<'a, K: Eq + Hash + Debug, V, T: Debug> Debug for MappedRefMut<'a, K, V, T> {
+impl<'a, K: Eq + Hash + Debug, T: Debug> Debug for MappedRefMut<'a, K, T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MappedRefMut")
             .field("k", &self.k)
@@ -319,7 +314,7 @@ impl<'a, K: Eq + Hash + Debug, V, T: Debug> Debug for MappedRefMut<'a, K, V, T> 
     }
 }
 
-impl<'a, K: Eq + Hash, V, T> Deref for MappedRefMut<'a, K, V, T> {
+impl<'a, K: Eq + Hash, T> Deref for MappedRefMut<'a, K, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -327,7 +322,7 @@ impl<'a, K: Eq + Hash, V, T> Deref for MappedRefMut<'a, K, V, T> {
     }
 }
 
-impl<'a, K: Eq + Hash, V, T> DerefMut for MappedRefMut<'a, K, V, T> {
+impl<'a, K: Eq + Hash, T> DerefMut for MappedRefMut<'a, K, T> {
     fn deref_mut(&mut self) -> &mut T {
         self.value_mut()
     }

--- a/src/rayon/map.rs
+++ b/src/rayon/map.rs
@@ -1,4 +1,4 @@
-use crate::lock::RwLock;
+use crate::lock::{RwLock, RwLockReadGuardDetached, RwLockWriteGuardDetached};
 use crate::mapref::multiple::{RefMulti, RefMutMulti};
 use crate::{DashMap, HashMap};
 use core::hash::{BuildHasher, Hash};
@@ -135,8 +135,12 @@ where
         self.shards
             .into_par_iter()
             .flat_map_iter(|shard| unsafe {
-                let guard = Arc::new(shard.read());
-                guard.iter().map(move |b| {
+                // SAFETY: we keep the guard alive with the shard iterator,
+                // and with any refs produced by the iterator
+                let (guard, shard) = RwLockReadGuardDetached::detach_from(shard.read());
+
+                let guard = Arc::new(guard);
+                shard.iter().map(move |b| {
                     let guard = Arc::clone(&guard);
                     let (k, v) = b.as_ref();
                     RefMulti::new(guard, k, v)
@@ -193,8 +197,12 @@ where
         self.shards
             .into_par_iter()
             .flat_map_iter(|shard| unsafe {
-                let guard = Arc::new(shard.write());
-                guard.iter().map(move |b| {
+                // SAFETY: we keep the guard alive with the shard iterator,
+                // and with any refs produced by the iterator
+                let (guard, shard) = RwLockWriteGuardDetached::detach_from(shard.write());
+
+                let guard = Arc::new(guard);
+                shard.iter().map(move |b| {
                     let guard = Arc::clone(&guard);
                     let (k, v) = b.as_mut();
                     RefMutMulti::new(guard, k, v)

--- a/src/rayon/map.rs
+++ b/src/rayon/map.rs
@@ -95,13 +95,7 @@ where
     {
         Vec::from(self.shards)
             .into_par_iter()
-            .flat_map_iter(|shard| {
-                shard
-                    .into_inner()
-                    .into_inner()
-                    .into_iter()
-                    .map(|(k, v)| (k, v.into_inner()))
-            })
+            .flat_map_iter(|shard| shard.into_inner().into_inner().into_iter())
             .drive_unindexed(consumer)
     }
 }
@@ -145,7 +139,7 @@ where
                 guard.iter().map(move |b| {
                     let guard = Arc::clone(&guard);
                     let (k, v) = b.as_ref();
-                    RefMulti::new(guard, k, v.get())
+                    RefMulti::new(guard, k, v)
                 })
             })
             .drive_unindexed(consumer)
@@ -203,7 +197,7 @@ where
                 guard.iter().map(move |b| {
                     let guard = Arc::clone(&guard);
                     let (k, v) = b.as_mut();
-                    RefMutMulti::new(guard, k, v.get_mut())
+                    RefMutMulti::new(guard, k, v)
                 })
             })
             .drive_unindexed(consumer)

--- a/src/read_only.rs
+++ b/src/read_only.rs
@@ -88,7 +88,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> ReadOnlyView<K, V, S>
 
         shard.find(hash, |(k, _v)| key == k.borrow()).map(|b| {
             let (k, v) = unsafe { b.as_ref() };
-            (k, v.get())
+            (k, v)
         })
     }
 
@@ -100,7 +100,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> ReadOnlyView<K, V, S>
                 .flat_map(|shard| shard.iter())
                 .map(|b| {
                     let (k, v) = b.as_ref();
-                    (k, v.get())
+                    (k, v)
                 })
         }
     }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -185,11 +185,11 @@ impl<'a, K: Eq + Hash, V: Serialize> Serialize for mapref::one::RefMut<'a, K, V>
     serialize_impl! {}
 }
 
-impl<'a, K: Eq + Hash, V, T: Serialize> Serialize for mapref::one::MappedRef<'a, K, V, T> {
+impl<'a, K: Eq + Hash, T: Serialize> Serialize for mapref::one::MappedRef<'a, K, T> {
     serialize_impl! {}
 }
 
-impl<'a, K: Eq + Hash, V, T: Serialize> Serialize for mapref::one::MappedRefMut<'a, K, V, T> {
+impl<'a, K: Eq + Hash, T: Serialize> Serialize for mapref::one::MappedRefMut<'a, K, T> {
     serialize_impl! {}
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,9 @@
 //! This module is full of hackery and dark magic.
 //! Either spend a day fixing it and quietly submit a PR or don't mention it to anybody.
 use core::{mem, ptr};
+use std::{marker::PhantomData, mem::ManuallyDrop};
+
+use lock_api::{RawRwLock, RawRwLockDowngrade, RwLockReadGuard, RwLockWriteGuard};
 
 pub const fn ptr_size_bits() -> usize {
     mem::size_of::<usize>() * 8
@@ -27,6 +30,95 @@ impl Drop for AbortOnPanic {
     fn drop(&mut self) {
         if std::thread::panicking() {
             std::process::abort()
+        }
+    }
+}
+
+
+/// A [`RwLockReadGuard`], without the data
+pub(crate) struct RwLockReadGuardDetached<'a, R: RawRwLock> {
+    lock: &'a R,
+    _marker: PhantomData<R::GuardMarker>,
+}
+
+impl<R: RawRwLock> Drop for RwLockReadGuardDetached<'_, R> {
+    fn drop(&mut self) {
+        // Safety: An RwLockReadGuardDetached always holds a shared lock.
+        unsafe {
+            self.lock.unlock_shared();
+        }
+    }
+}
+
+/// A [`RwLockWriteGuard`], without the data
+pub(crate) struct RwLockWriteGuardDetached<'a, R: RawRwLock> {
+    lock: &'a R,
+    _marker: PhantomData<R::GuardMarker>,
+}
+
+impl<R: RawRwLock> Drop for RwLockWriteGuardDetached<'_, R> {
+    fn drop(&mut self) {
+        // Safety: An RwLockWriteGuardDetached always holds an exclusive lock.
+        unsafe {
+            self.lock.unlock_exclusive();
+        }
+    }
+}
+
+impl<'a, R: RawRwLock> RwLockReadGuardDetached<'a, R> {
+    /// Separates the data from the [`RwLockReadGuard`]
+    ///
+    /// # Safety
+    ///
+    /// The data must not outlive the detached guard
+    pub(crate) unsafe fn detach_from<T>(guard: RwLockReadGuard<'a, R, T>) -> (Self, &'a T) {
+        let rwlock = RwLockReadGuard::rwlock(&ManuallyDrop::new(guard));
+
+        // Safety: There will be no concurrent writes as we are "forgetting" the existing guard,
+        // with the safety assumption that the caller will not drop the new detached guard early.
+        let data = unsafe { &*rwlock.data_ptr() };
+        let guard = RwLockReadGuardDetached {
+            // Safety: We are imitating the original RwLockReadGuard. It's the callers
+            // responsibility to not drop the guard early.
+            lock: unsafe { rwlock.raw() },
+            _marker: PhantomData,
+        };
+        (guard, data)
+    }
+}
+
+impl<'a, R: RawRwLock> RwLockWriteGuardDetached<'a, R> {
+    /// Separates the data from the [`RwLockWriteGuard`]
+    ///
+    /// # Safety
+    ///
+    /// The data must not outlive the detached guard
+    pub(crate) unsafe fn detach_from<T>(guard: RwLockWriteGuard<'a, R, T>) -> (Self, &'a mut T) {
+        let rwlock = RwLockWriteGuard::rwlock(&ManuallyDrop::new(guard));
+
+        // Safety: There will be no concurrent reads/writes as we are "forgetting" the existing guard,
+        // with the safety assumption that the caller will not drop the new detached guard early.
+        let data = unsafe { &mut *rwlock.data_ptr() };
+        let guard = RwLockWriteGuardDetached {
+            // Safety: We are imitating the original RwLockWriteGuard. It's the callers
+            // responsibility to not drop the guard early.
+            lock: unsafe { rwlock.raw() },
+            _marker: PhantomData,
+        };
+        (guard, data)
+    }
+}
+
+impl<'a, R: RawRwLockDowngrade> RwLockWriteGuardDetached<'a, R> {
+    /// # Safety
+    ///
+    /// The associated data must not mut mutated after downgrading
+    pub(crate) unsafe fn downgrade(self) -> RwLockReadGuardDetached<'a, R> {
+        // Safety: An RwLockWriteGuardDetached always holds an exclusive lock.
+        unsafe { self.lock.downgrade() }
+        RwLockReadGuardDetached {
+            lock: self.lock,
+            _marker: self._marker,
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,5 @@
 //! This module is full of hackery and dark magic.
 //! Either spend a day fixing it and quietly submit a PR or don't mention it to anybody.
-use core::cell::UnsafeCell;
 use core::{mem, ptr};
 
 pub const fn ptr_size_bits() -> usize {
@@ -19,63 +18,6 @@ pub fn map_in_place_2<T, U, F: FnOnce(U, T) -> T>((k, v): (U, &mut T), f: F) {
         // If we made it here, the calling thread could have already have panicked, in which case
         // We know that the closure did not panic, so don't bother checking.
         std::mem::forget(promote_panic_to_abort);
-    }
-}
-
-/// A simple wrapper around `T`
-///
-/// This is to prevent UB when using `HashMap::get_key_value`, because
-/// `HashMap` doesn't expose an api to get the key and value, where
-/// the value is a `&mut T`.
-///
-/// See [#10](https://github.com/xacrimon/dashmap/issues/10) for details
-///
-/// This type is meant to be an implementation detail, but must be exposed due to the `Dashmap::shards`
-#[repr(transparent)]
-pub struct SharedValue<T> {
-    value: UnsafeCell<T>,
-}
-
-impl<T: Clone> Clone for SharedValue<T> {
-    fn clone(&self) -> Self {
-        let inner = self.get().clone();
-
-        Self {
-            value: UnsafeCell::new(inner),
-        }
-    }
-}
-
-unsafe impl<T: Send> Send for SharedValue<T> {}
-
-unsafe impl<T: Sync> Sync for SharedValue<T> {}
-
-impl<T> SharedValue<T> {
-    /// Create a new `SharedValue<T>`
-    pub const fn new(value: T) -> Self {
-        Self {
-            value: UnsafeCell::new(value),
-        }
-    }
-
-    /// Get a shared reference to `T`
-    pub fn get(&self) -> &T {
-        unsafe { &*self.value.get() }
-    }
-
-    /// Get an unique reference to `T`
-    pub fn get_mut(&mut self) -> &mut T {
-        unsafe { &mut *self.value.get() }
-    }
-
-    /// Unwraps the value
-    pub fn into_inner(self) -> T {
-        self.value.into_inner()
-    }
-
-    /// Get a mutable raw pointer to the underlying value
-    pub(crate) fn as_ptr(&self) -> *mut T {
-        self.value.get()
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -34,7 +34,6 @@ impl Drop for AbortOnPanic {
     }
 }
 
-
 /// A [`RwLockReadGuard`], without the data
 pub(crate) struct RwLockReadGuardDetached<'a, R: RawRwLock> {
     lock: &'a R,


### PR DESCRIPTION
(stacked on top of #322)

I came up with this novel abstraction for reducing the dependencies on pointers within dashmap. We need to hold the lock guard for the shard.

Since Ref/Mut wants to get proper reference values eventually, it doesn't matter whether you convert pointers early or later. It seems to work all the same. 

Thus, we can convert 

```rust
pub struct Ref<'a, K, V> {
    _guard: RwLockReadGuard<'a, HashMap<K, V>>,
    k: *const K,
    v: *const V,
}
```

into

```rust
pub struct Ref<'a, K, V> {
    _guard: RwLockReadGuardDetached<'a>,
    k: &'a K,
    v: &'a V,
}
```

Since the detached guard does not own the data, it's inherently unsafe, but from my understanding and from asking others, it is still sound as long as the data is still coupled with the guard. `Ref`/`Entry` APIs still hold the guard, which upholds this invariant.

As a by-product of using this in mapref::multiple, I noticed that the RwLock guard is marked as GuardNotSend, meanwhile every iterator/ref is manually marked as Send/Sync. This seemed redundant, so I've additionally made the guard Send and then removed all manual send/sync impls.