### PR TITLE
Implement Eq and PartialEq for DashMap and DashSet

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1343,6 +1343,21 @@ where
     }
 }
 
+impl<'a, K: 'a + Eq + Hash, V: 'a + PartialEq, S: BuildHasher + Clone> PartialEq
+    for DashMap<K, V, S>
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.len() == other.len()
+            && self.iter().all(|r| {
+                other
+                    .get(r.key())
+                    .map_or(false, |ro| r.value() == ro.value())
+            })
+    }
+}
+
+impl<'a, K: 'a + Eq + Hash, V: 'a + Eq, S: BuildHasher + Clone> Eq for DashMap<K, V, S> {}
+
 impl<K: Eq + Hash, V, S: BuildHasher + Clone> IntoIterator for DashMap<K, V, S> {
     type Item = (K, V);
 
@@ -1429,6 +1444,25 @@ mod tests {
         dm.insert(0, 0);
 
         assert_eq!(dm.get(&0).unwrap().value(), &0);
+    }
+
+    #[test]
+    fn test_equal() {
+        let dm1 = DashMap::new();
+        let dm2 = DashMap::new();
+        assert_eq!(dm1, dm2);
+
+        dm1.insert(0, "Hello, world!");
+        assert_ne!(dm1, dm2);
+
+        dm1.insert(1, "Goodbye, world!");
+        assert_ne!(dm1, dm2);
+
+        dm2.insert(0, "Hello, world!");
+        assert_ne!(dm1, dm2);
+
+        dm2.insert(1, "Goodbye, world!");
+        assert_eq!(dm1, dm2);
     }
 
     #[test]

--- a/src/set.rs
+++ b/src/set.rs
@@ -382,6 +382,14 @@ impl<'a, K: 'a + Eq + Hash, S: BuildHasher + Clone> DashSet<K, S> {
     }
 }
 
+impl<K: Eq + Hash, S: BuildHasher + Clone> PartialEq for DashSet<K, S> {
+    fn eq(&self, other: &Self) -> bool {
+        self.len() == other.len() && self.iter().all(|r| other.contains(r.key()))
+    }
+}
+
+impl<K: Eq + Hash, S: BuildHasher + Clone> Eq for DashSet<K, S> {}
+
 impl<K: Eq + Hash, S: BuildHasher + Clone> IntoIterator for DashSet<K, S> {
     type Item = K;
 
@@ -447,6 +455,25 @@ mod tests {
         set.insert(0);
 
         assert_eq!(set.get(&0).as_deref(), Some(&0));
+    }
+
+    #[test]
+    fn test_equal() {
+        let set1 = DashSet::new();
+        let set2 = DashSet::new();
+        assert_eq!(set1, set2);
+
+        set1.insert("Hello, world!");
+        assert_ne!(set1, set2);
+
+        set1.insert("Goodbye, world!");
+        assert_ne!(set1, set2);
+
+        set2.insert("Hello, world!");
+        assert_ne!(set1, set2);
+
+        set2.insert("Goodbye, world!");
+        assert_eq!(set1, set2);
     }
 
     #[test]


### PR DESCRIPTION
Hi, I was hoping to revisit #138, where you said

> They aren't implemented because equality makes no sense for a concurrent map. Fundamentally you never really have to compare two and if you do, you're probably architecting your code in a non-optimal way.

I agree with this entirely in the context of real, running code, but am hoping to change your mind on the basis of testing. Providing equality methods makes writing test cases that reason about the contents of `DashMap`'s and `DashSet`'s much more concise, and testing is arguably the one scenario where ergonomics & readability clearly outweigh performance. Please consider giving users the option, even if you feel obligated to warn them against it, to use these traits.

Happy to make any tweaks and add documentation at your request. Thanks for all the work on this project!