### PR TITLE
document behavior of insert methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -480,6 +480,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     }
 
     /// Inserts a key and a value into the map. Returns the old value associated with the key if there was one.
+    /// Does not update the key if it was already present.
     ///
     /// **Locking behaviour:** May deadlock if called when holding any sort of reference into the map.
     ///

--- a/src/set.rs
+++ b/src/set.rs
@@ -193,6 +193,7 @@ impl<'a, K: 'a + Eq + Hash, S: BuildHasher + Clone> DashSet<K, S> {
     }
 
     /// Inserts a key into the set. Returns true if the key was not already in the set.
+    /// Does not update the key if it was already present.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
There are two possible behaviors for pre-existing keys, either the key is replaced or it is not, and which behavior is exhibited should be documented.

Not sure what the intended line length or other style restrictions on doc comments are so I've just added these short sentences on a new line. Let me know if they need to be reflowed or something.