### PR TITLE
Update doc comments for Entry and EntryRef or_insert method

### DIFF
--- a/src/mapref/entry.rs
+++ b/src/mapref/entry.rs
@@ -53,7 +53,7 @@ impl<'a, K: Eq + Hash, V> Entry<'a, K, V> {
     }
 
     /// Return a mutable reference to the element if it exists,
-    /// otherwise a provided value and return a mutable reference to that.
+    /// otherwise insert a provided value and return a mutable reference to that.
     pub fn or_insert(self, value: V) -> RefMut<'a, K, V> {
         match self {
             Entry::Occupied(entry) => entry.into_ref(),

--- a/src/mapref/entry_ref.rs
+++ b/src/mapref/entry_ref.rs
@@ -56,7 +56,7 @@ impl<'a, 'q, K: Eq + Hash + From<&'q Q>, Q, V> EntryRef<'a, 'q, K, Q, V> {
     }
 
     /// Return a mutable reference to the element if it exists,
-    /// otherwise a provided value and return a mutable reference to that.
+    /// otherwise insert a provided value and return a mutable reference to that.
     pub fn or_insert(self, value: V) -> RefMut<'a, K, V> {
         match self {
             EntryRef::Occupied(entry) => entry.into_ref(),


### PR DESCRIPTION
Comments for the or_insert method for Entry and EntryRef were missing a word. Aligning with the other or_* methods.

Just something I noticed while reading the docs