### PR TITLE
add explicit lifetime for `Ref` and `RefMulti`

### DIFF
--- a/src/mapref/multiple.rs
+++ b/src/mapref/multiple.rs
@@ -18,15 +18,15 @@ impl<'a, K: Eq + Hash, V> RefMulti<'a, K, V> {
         }
     }
 
-    pub fn key(&self) -> &K {
+    pub fn key(&self) -> &'a K {
         self.pair().0
     }
 
-    pub fn value(&self) -> &V {
+    pub fn value(&self) -> &'a V {
         self.pair().1
     }
 
-    pub fn pair(&self) -> (&K, &V) {
+    pub fn pair(&self) -> (&'a K, &'a V) {
         (self.k, self.v)
     }
 }
@@ -34,7 +34,7 @@ impl<'a, K: Eq + Hash, V> RefMulti<'a, K, V> {
 impl<'a, K: Eq + Hash, V> Deref for RefMulti<'a, K, V> {
     type Target = V;
 
-    fn deref(&self) -> &V {
+    fn deref(&self) -> &'a V {
         self.value()
     }
 }
@@ -86,5 +86,24 @@ impl<'a, K: Eq + Hash, V> Deref for RefMutMulti<'a, K, V> {
 impl<'a, K: Eq + Hash, V> DerefMut for RefMutMulti<'a, K, V> {
     fn deref_mut(&mut self) -> &mut V {
         self.value_mut()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::DashMap;
+
+    #[test]
+    #[allow(unused)]
+    fn lifetime() {
+        fn get_key<'a>(data: &'a DashMap<String, String>) -> impl Iterator<Item = &'a str> {
+            data.iter().map(|item| item.key().as_str())
+        }
+        fn get_value<'a>(data: &'a DashMap<String, String>) -> impl Iterator<Item = &'a str> {
+            data.iter().map(|item| item.value().as_str())
+        }
+        fn get_pair(data: &DashMap<String, String>) -> impl Iterator<Item = (&String, &String)> {
+            data.iter().map(|item| item.pair())
+        }
     }
 }

--- a/src/mapref/one.rs
+++ b/src/mapref/one.rs
@@ -18,15 +18,15 @@ impl<'a, K: Eq + Hash, V> Ref<'a, K, V> {
         }
     }
 
-    pub fn key(&self) -> &K {
+    pub fn key(&self) -> &'a K {
         self.pair().0
     }
 
-    pub fn value(&self) -> &V {
+    pub fn value(&self) -> &'a V {
         self.pair().1
     }
 
-    pub fn pair(&self) -> (&K, &V) {
+    pub fn pair(&self) -> (&'a K, &'a V) {
         (self.k, self.v)
     }
 
@@ -69,7 +69,7 @@ impl<'a, K: Eq + Hash + Debug, V: Debug> Debug for Ref<'a, K, V> {
 impl<'a, K: Eq + Hash, V> Deref for Ref<'a, K, V> {
     type Target = V;
 
-    fn deref(&self) -> &V {
+    fn deref(&self) -> &'a V {
         self.value()
     }
 }
@@ -172,15 +172,15 @@ pub struct MappedRef<'a, K, T: ?Sized> {
 }
 
 impl<'a, K: Eq + Hash, T: ?Sized> MappedRef<'a, K, T> {
-    pub fn key(&self) -> &K {
+    pub fn key(&self) -> &'a K {
         self.pair().0
     }
 
-    pub fn value(&self) -> &T {
+    pub fn value(&self) -> &'a T {
         self.pair().1
     }
 
-    pub fn pair(&self) -> (&K, &T) {
+    pub fn pair(&self) -> (&'a K, &'a T) {
         (self.k, self.v)
     }
 
@@ -224,7 +224,7 @@ impl<'a, K: Eq + Hash + Debug, T: Debug + ?Sized> Debug for MappedRef<'a, K, T> 
 impl<'a, K: Eq + Hash, T: ?Sized> Deref for MappedRef<'a, K, T> {
     type Target = T;
 
-    fn deref(&self) -> &T {
+    fn deref(&self) -> &'a T {
         self.value()
     }
 }
@@ -383,5 +383,30 @@ mod tests {
 
             assert_eq!(hello_ref.value(), "hello");
         };
+    }
+
+    #[test]
+    #[allow(unused)]
+    fn lifetime() {
+        fn get_key<'a>(data: &'a DashMap<String, String>) -> Option<&'a str> {
+            data.get("key").map(|item| item.key().as_str())
+        }
+        fn get_value<'a>(data: &'a DashMap<String, String>) -> Option<&'a str> {
+            data.get("key").map(|item| item.value().as_str())
+        }
+        fn get_pair(data: &DashMap<String, String>) -> Option<(&String, &String)> {
+            data.get("key").map(|item| item.pair())
+        }
+        fn get_mapped_key<'a>(data: &'a DashMap<String, String>) -> Option<&'a str> {
+            data.get("key")
+                .map(|item| item.map(|item| item).key().as_str())
+        }
+        fn get_mapped_value<'a>(data: &'a DashMap<String, String>) -> Option<&'a str> {
+            data.get("key")
+                .map(|item| item.map(|item| item).value().as_str())
+        }
+        fn get_mapped_pair(data: &DashMap<String, String>) -> Option<(&String, &String)> {
+            data.get("key").map(|item| item.map(|item| item).pair())
+        }
     }
 }

--- a/src/setref/multiple.rs
+++ b/src/setref/multiple.rs
@@ -11,7 +11,7 @@ impl<'a, K: Eq + Hash> RefMulti<'a, K> {
         Self { inner }
     }
 
-    pub fn key(&self) -> &K {
+    pub fn key(&self) -> &'a K {
         self.inner.key()
     }
 }
@@ -19,7 +19,20 @@ impl<'a, K: Eq + Hash> RefMulti<'a, K> {
 impl<'a, K: Eq + Hash> Deref for RefMulti<'a, K> {
     type Target = K;
 
-    fn deref(&self) -> &K {
+    fn deref(&self) -> &'a K {
         self.key()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::DashSet;
+
+    #[test]
+    #[allow(unused)]
+    fn lifetime() {
+        fn get_key<'a>(data: &'a DashSet<String>) -> impl Iterator<Item = &'a str> {
+            data.iter().map(|item| item.key().as_str())
+        }
     }
 }

--- a/src/setref/one.rs
+++ b/src/setref/one.rs
@@ -11,7 +11,7 @@ impl<'a, K: Eq + Hash> Ref<'a, K> {
         Self { inner }
     }
 
-    pub fn key(&self) -> &K {
+    pub fn key(&self) -> &'a K {
         self.inner.key()
     }
 }
@@ -19,7 +19,20 @@ impl<'a, K: Eq + Hash> Ref<'a, K> {
 impl<'a, K: Eq + Hash> Deref for Ref<'a, K> {
     type Target = K;
 
-    fn deref(&self) -> &K {
+    fn deref(&self) -> &'a K {
         self.key()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::DashSet;
+
+    #[test]
+    #[allow(unused)]
+    fn lifetime() {
+        fn get_key<'a>(data: &'a DashSet<String>) -> Option<&'a str> {
+            data.get("key").map(|item| item.key().as_str())
+        }
     }
 }


### PR DESCRIPTION
Currently for the `key`, `value` and `pair` methods of `Ref` and `RefMulti`, their return type lifetimes are tied to `&self` because they are elided. This will cause compilation errors when a function needs returning a reference that holds to a map/set entry. See the tests.

This PR fixes this problem.