### PR TITLE
Remove unnecessary use of `std::thread::panicking`

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -12,23 +12,20 @@ pub fn map_in_place_2<T, U, F: FnOnce(U, T) -> T>((k, v): (U, &mut T), f: F) {
         // # Safety
         //
         // If the closure panics, we must abort otherwise we could double drop `T`
-        let promote_panic_to_abort = AbortOnPanic;
+        let promote_panic_to_abort = AbortOnDrop;
 
         ptr::write(v, f(k, ptr::read(v)));
 
-        // If we made it here, the calling thread could have already have panicked, in which case
-        // We know that the closure did not panic, so don't bother checking.
+        // If we made it here, the operation has already completed, so no need to panic.
         std::mem::forget(promote_panic_to_abort);
     }
 }
 
-struct AbortOnPanic;
+struct AbortOnDrop;
 
-impl Drop for AbortOnPanic {
+impl Drop for AbortOnDrop {
     fn drop(&mut self) {
-        if std::thread::panicking() {
-            std::process::abort()
-        }
+        std::process::abort()
     }
 }
 


### PR DESCRIPTION
`std::thread::panicking` is [notoriously brittle](https://github.com/rust-lang/rust/issues/143612) due to reentrant panics and function calls within panic handlers, but it can be straightforwardly avoided in this case. Removing it was safe since #300 added `forget`.