### PR TITLE
Various simplifications

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,7 +259,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
     /// mappings.insert(8, 16);
     /// ```
     pub fn with_capacity_and_hasher_and_shard_amount(
-        mut capacity: usize,
+        capacity: usize,
         hasher: S,
         shard_amount: usize,
     ) -> Self {
@@ -267,13 +267,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
         assert!(shard_amount.is_power_of_two());
 
         let shift = usize::BITS as usize - ncb(shard_amount);
-
-        if capacity != 0 {
-            capacity = (capacity + (shard_amount - 1)) & !(shard_amount - 1);
-        }
-
-        let cps = capacity / shard_amount;
-
+        let cps = (capacity + (shard_amount - 1)) / shard_amount;
         let shards = (0..shard_amount)
             .map(|_| CachePadded::new(RwLock::new(HashMap::with_capacity(cps))))
             .collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ where
     }
 }
 
-impl<'a, K: 'a + Eq + Hash, V: 'a> DashMap<K, V, RandomState> {
+impl<K: Eq + Hash, V> DashMap<K, V, RandomState> {
     /// Creates a new DashMap with a capacity of 0.
     ///
     /// # Examples
@@ -1336,9 +1336,7 @@ where
     }
 }
 
-impl<'a, K: 'a + Eq + Hash, V: 'a + PartialEq, S: BuildHasher + Clone> PartialEq
-    for DashMap<K, V, S>
-{
+impl<K: Eq + Hash, V: PartialEq, S: BuildHasher + Clone> PartialEq for DashMap<K, V, S> {
     fn eq(&self, other: &Self) -> bool {
         self.len() == other.len()
             && self.iter().all(|r| {
@@ -1349,7 +1347,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a + PartialEq, S: BuildHasher + Clone> PartialEq
     }
 }
 
-impl<'a, K: 'a + Eq + Hash, V: 'a + Eq, S: BuildHasher + Clone> Eq for DashMap<K, V, S> {}
+impl<K: Eq + Hash, V: Eq, S: BuildHasher + Clone> Eq for DashMap<K, V, S> {}
 
 impl<K: Eq + Hash, V, S: BuildHasher + Clone> IntoIterator for DashMap<K, V, S> {
     type Item = (K, V);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1259,7 +1259,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> DashMap<K, V, S>
     }
 
     fn _clear(&self) {
-        self._retain(|_, _| false)
+        self.shards.iter().for_each(|s| s.write().clear());
     }
 
     fn _contains_key<Q>(&'a self, key: &Q) -> bool

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,7 +266,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher + Clone> DashMap<K, V, S> {
         assert!(shard_amount > 1);
         assert!(shard_amount.is_power_of_two());
 
-        let shift = util::ptr_size_bits() - ncb(shard_amount);
+        let shift = usize::BITS as usize - ncb(shard_amount);
 
         if capacity != 0 {
             capacity = (capacity + (shard_amount - 1)) & !(shard_amount - 1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1164,10 +1164,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> DashMap<K, V, S>
 
         let idx = self.determine_shard(hash as usize);
 
-        let shard = match self.shards[idx].try_write() {
-            Some(shard) => shard,
-            None => return None,
-        };
+        let shard = self.shards[idx].try_write()?;
         // SAFETY: The data will not outlive the guard, since we pass the guard to `Entry`.
         let (guard, shard) = unsafe { RwLockWriteGuardDetached::detach_from(shard) };
 
@@ -1227,10 +1224,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> DashMap<K, V, S>
 
         let idx = self.determine_shard(hash as usize);
 
-        let shard = match self.shards[idx].try_write() {
-            Some(shard) => shard,
-            None => return None,
-        };
+        let shard = self.shards[idx].try_write()?;
         // SAFETY: The data will not outlive the guard, since we pass the guard to `Entry`.
         let (guard, shard) = unsafe { RwLockWriteGuardDetached::detach_from(shard) };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1094,9 +1094,7 @@ impl<'a, K: 'a + Eq + Hash, V: 'a, S: 'a + BuildHasher + Clone> DashMap<K, V, S>
 
     fn _shrink_to_fit(&self) {
         self.shards.iter().for_each(|s| {
-            let mut shard = s.write();
-            let size = shard.len();
-            shard.shrink_to(size, |(k, _v)| {
+            s.write().shrink_to_fit(|(k, _v)| {
                 let mut hasher = self.hasher.build_hasher();
                 k.hash(&mut hasher);
                 hasher.finish()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1333,11 +1333,9 @@ where
 impl<K: Eq + Hash, V: PartialEq, S: BuildHasher + Clone> PartialEq for DashMap<K, V, S> {
     fn eq(&self, other: &Self) -> bool {
         self.len() == other.len()
-            && self.iter().all(|r| {
-                other
-                    .get(r.key())
-                    .map_or(false, |ro| r.value() == ro.value())
-            })
+            && self
+                .iter()
+                .all(|r| other.get(r.key()).is_some_and(|ro| r.value() == ro.value()))
     }
 }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -50,7 +50,7 @@ where
     }
 }
 
-impl<'a, K: 'a + Eq + Hash> DashSet<K, RandomState> {
+impl<K: Eq + Hash> DashSet<K, RandomState> {
     /// Creates a new DashSet with a capacity of 0.
     ///
     /// # Examples

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,11 +1,7 @@
-use core::{mem, ptr};
+use core::ptr;
 use std::{marker::PhantomData, mem::ManuallyDrop};
 
 use lock_api::{RawRwLock, RawRwLockDowngrade, RwLockReadGuard, RwLockWriteGuard};
-
-pub const fn ptr_size_bits() -> usize {
-    mem::size_of::<usize>() * 8
-}
 
 pub fn map_in_place_2<T, U, F: FnOnce(U, T) -> T>((k, v): (U, &mut T), f: F) {
     unsafe {


### PR DESCRIPTION
- Use implementations of `shrink_to_fit` and `clear` from hashbrown instead of hand-rolling them for readability and/or performance (the latter more applicable to `clear` than `shrink_to_fit`).
- Simplify some arithmetic in capacity calculations.
- Also fixed warnings reported by modern clippy: unused lifetimes, hand-rolled `?`, hand-rolled `is_some_and`.

I understand there might not be bandwidth for reviewing trivial PRs, feel free to close without justification if that's a problem.