### PR TITLE
Relax where-bounds on struct definitions and impl-blocks where possible

### DIFF
--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -1,11 +1,11 @@
 use arbitrary::{Arbitrary, Unstructured};
-use core::hash::BuildHasher;
+use core::hash::{BuildHasher, Hash};
 
 impl<'a, K, V, S> Arbitrary<'a> for crate::DashMap<K, V, S>
 where
-    K: Eq + std::hash::Hash + Arbitrary<'a>,
+    K: Eq + Hash + Arbitrary<'a>,
     V: Arbitrary<'a>,
-    S: Default + BuildHasher + Clone,
+    S: Default + BuildHasher,
 {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         u.arbitrary_iter()?.collect()

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -4,7 +4,6 @@ use hashbrown::hash_table;
 use super::mapref::multiple::{RefMulti, RefMutMulti};
 use crate::lock::{RwLock, RwLockReadGuardDetached, RwLockWriteGuardDetached};
 use crate::{DashMap, HashMap};
-use core::hash::Hash;
 use std::sync::Arc;
 
 /// Iterator over a DashMap yielding key value pairs.
@@ -25,7 +24,7 @@ pub struct OwningIter<K, V> {
     current: Option<GuardOwningIter<K, V>>,
 }
 
-impl<K: Eq + Hash, V> OwningIter<K, V> {
+impl<K, V> OwningIter<K, V> {
     pub(crate) fn new<S>(map: DashMap<K, V, S>) -> Self {
         Self {
             shards: map.shards.into_vec().into_iter(),
@@ -36,7 +35,7 @@ impl<K: Eq + Hash, V> OwningIter<K, V> {
 
 type GuardOwningIter<K, V> = hash_table::IntoIter<(K, V)>;
 
-impl<K: Eq + Hash, V> Iterator for OwningIter<K, V> {
+impl<K, V> Iterator for OwningIter<K, V> {
     type Item = (K, V);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -79,7 +78,11 @@ pub struct Iter<'a, K, V> {
     current: Option<GuardIter<'a, K, V>>,
 }
 
-impl<'i, K: Clone + Hash + Eq, V: Clone> Clone for Iter<'i, K, V> {
+impl<'a, K, V> Clone for Iter<'a, K, V>
+where
+    K: Clone,
+    V: Clone,
+{
     fn clone(&self) -> Self {
         Iter {
             shards: self.shards.clone(),
@@ -88,7 +91,7 @@ impl<'i, K: Clone + Hash + Eq, V: Clone> Clone for Iter<'i, K, V> {
     }
 }
 
-impl<'a, K: Eq + Hash + 'a, V: 'a> Iter<'a, K, V> {
+impl<'a, K, V> Iter<'a, K, V> {
     pub(crate) fn new<S>(map: &'a DashMap<K, V, S>) -> Self {
         Self {
             shards: map.shards.iter(),
@@ -97,7 +100,7 @@ impl<'a, K: Eq + Hash + 'a, V: 'a> Iter<'a, K, V> {
     }
 }
 
-impl<'a, K: Eq + Hash + 'a, V: 'a> Iterator for Iter<'a, K, V> {
+impl<'a, K, V> Iterator for Iter<'a, K, V> {
     type Item = RefMulti<'a, K, V>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -138,7 +141,7 @@ pub struct IterMut<'a, K, V> {
     current: Option<GuardIterMut<'a, K, V>>,
 }
 
-impl<'a, K: Eq + Hash + 'a, V: 'a> IterMut<'a, K, V> {
+impl<'a, K, V> IterMut<'a, K, V> {
     pub(crate) fn new<S>(map: &'a DashMap<K, V, S>) -> Self {
         Self {
             shards: map.shards.iter(),
@@ -147,7 +150,7 @@ impl<'a, K: Eq + Hash + 'a, V: 'a> IterMut<'a, K, V> {
     }
 }
 
-impl<'a, K: Eq + Hash + 'a, V: 'a> Iterator for IterMut<'a, K, V> {
+impl<'a, K, V> Iterator for IterMut<'a, K, V> {
     type Item = RefMutMulti<'a, K, V>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/iter_set.rs
+++ b/src/iter_set.rs
@@ -1,17 +1,16 @@
 use crate::setref::multiple::RefMulti;
-use core::hash::Hash;
 
 pub struct OwningIter<K> {
     inner: crate::iter::OwningIter<K, ()>,
 }
 
-impl<K: Eq + Hash> OwningIter<K> {
+impl<K> OwningIter<K> {
     pub(crate) fn new(inner: crate::iter::OwningIter<K, ()>) -> Self {
         Self { inner }
     }
 }
 
-impl<K: Eq + Hash> Iterator for OwningIter<K> {
+impl<K> Iterator for OwningIter<K> {
     type Item = K;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -23,13 +22,13 @@ pub struct Iter<'a, K> {
     inner: crate::iter::Iter<'a, K, ()>,
 }
 
-impl<'a, K: Eq + Hash + 'a> Iter<'a, K> {
+impl<'a, K> Iter<'a, K> {
     pub(crate) fn new(inner: crate::iter::Iter<'a, K, ()>) -> Self {
         Self { inner }
     }
 }
 
-impl<'a, K: Eq + Hash + 'a> Iterator for Iter<'a, K> {
+impl<'a, K> Iterator for Iter<'a, K> {
     type Item = RefMulti<'a, K>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/mapref/entry.rs
+++ b/src/mapref/entry.rs
@@ -2,7 +2,6 @@ use hashbrown::hash_table;
 
 use super::one::RefMut;
 use crate::lock::RwLockWriteGuardDetached;
-use core::hash::Hash;
 use core::mem;
 
 pub enum Entry<'a, K, V> {
@@ -10,7 +9,7 @@ pub enum Entry<'a, K, V> {
     Vacant(VacantEntry<'a, K, V>),
 }
 
-impl<'a, K: Eq + Hash, V> Entry<'a, K, V> {
+impl<'a, K, V> Entry<'a, K, V> {
     /// Apply a function to the stored value if it exists.
     pub fn and_modify(self, f: impl FnOnce(&mut V)) -> Self {
         match self {
@@ -117,7 +116,7 @@ pub struct VacantEntry<'a, K, V> {
     entry: hash_table::VacantEntry<'a, (K, V)>,
 }
 
-impl<'a, K: Eq + Hash, V> VacantEntry<'a, K, V> {
+impl<'a, K, V> VacantEntry<'a, K, V> {
     pub(crate) fn new(
         shard: RwLockWriteGuardDetached<'a>,
         key: K,
@@ -158,7 +157,7 @@ pub struct OccupiedEntry<'a, K, V> {
     key: K,
 }
 
-impl<'a, K: Eq + Hash, V> OccupiedEntry<'a, K, V> {
+impl<'a, K, V> OccupiedEntry<'a, K, V> {
     pub(crate) fn new(
         shard: RwLockWriteGuardDetached<'a>,
         key: K,

--- a/src/mapref/entry_ref.rs
+++ b/src/mapref/entry_ref.rs
@@ -2,7 +2,6 @@ use hashbrown::hash_table;
 
 use super::one::RefMut;
 use crate::lock::RwLockWriteGuardDetached;
-use core::hash::Hash;
 use std::mem;
 
 /// Entry with a borrowed key.
@@ -11,7 +10,7 @@ pub enum EntryRef<'a, 'q, K, Q, V> {
     Vacant(VacantEntryRef<'a, 'q, K, Q, V>),
 }
 
-impl<'a, 'q, K: Eq + Hash, Q, V> EntryRef<'a, 'q, K, Q, V> {
+impl<'a, 'q, K, Q, V> EntryRef<'a, 'q, K, Q, V> {
     /// Apply a function to the stored value if it exists.
     pub fn and_modify(self, f: impl FnOnce(&mut V)) -> Self {
         match self {
@@ -26,7 +25,10 @@ impl<'a, 'q, K: Eq + Hash, Q, V> EntryRef<'a, 'q, K, Q, V> {
     }
 }
 
-impl<'a, 'q, K: Eq + Hash + From<&'q Q>, Q, V> EntryRef<'a, 'q, K, Q, V> {
+impl<'a, 'q, K, Q, V> EntryRef<'a, 'q, K, Q, V>
+where
+    K: From<&'q Q>,
+{
     /// Get the key of the entry.
     pub fn key(&self) -> &Q {
         match *self {
@@ -120,7 +122,7 @@ pub struct VacantEntryRef<'a, 'q, K, Q, V> {
     key: &'q Q,
 }
 
-impl<'a, 'q, K: Eq + Hash, Q, V> VacantEntryRef<'a, 'q, K, Q, V> {
+impl<'a, 'q, K, Q, V> VacantEntryRef<'a, 'q, K, Q, V> {
     pub(crate) fn new(
         shard: RwLockWriteGuardDetached<'a>,
         key: &'q Q,
@@ -168,7 +170,7 @@ pub struct OccupiedEntryRef<'a, 'q, K, Q, V> {
     key: &'q Q,
 }
 
-impl<'a, 'q, K: Eq + Hash, Q, V> OccupiedEntryRef<'a, 'q, K, Q, V> {
+impl<'a, 'q, K, Q, V> OccupiedEntryRef<'a, 'q, K, Q, V> {
     pub(crate) fn new(
         shard: RwLockWriteGuardDetached<'a>,
         key: &'q Q,

--- a/src/mapref/multiple.rs
+++ b/src/mapref/multiple.rs
@@ -1,5 +1,4 @@
 use crate::lock::{RwLockReadGuardDetached, RwLockWriteGuardDetached};
-use core::hash::Hash;
 use core::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
@@ -9,7 +8,7 @@ pub struct RefMulti<'a, K, V> {
     v: &'a V,
 }
 
-impl<'a, K: Eq + Hash, V> RefMulti<'a, K, V> {
+impl<'a, K, V> RefMulti<'a, K, V> {
     pub(crate) fn new(guard: Arc<RwLockReadGuardDetached<'a>>, k: &'a K, v: &'a V) -> Self {
         Self {
             _guard: guard,
@@ -31,7 +30,7 @@ impl<'a, K: Eq + Hash, V> RefMulti<'a, K, V> {
     }
 }
 
-impl<'a, K: Eq + Hash, V> Deref for RefMulti<'a, K, V> {
+impl<'a, K, V> Deref for RefMulti<'a, K, V> {
     type Target = V;
 
     fn deref(&self) -> &V {
@@ -45,7 +44,7 @@ pub struct RefMutMulti<'a, K, V> {
     v: &'a mut V,
 }
 
-impl<'a, K: Eq + Hash, V> RefMutMulti<'a, K, V> {
+impl<'a, K, V> RefMutMulti<'a, K, V> {
     pub(crate) fn new(guard: Arc<RwLockWriteGuardDetached<'a>>, k: &'a K, v: &'a mut V) -> Self {
         Self {
             _guard: guard,
@@ -75,7 +74,7 @@ impl<'a, K: Eq + Hash, V> RefMutMulti<'a, K, V> {
     }
 }
 
-impl<'a, K: Eq + Hash, V> Deref for RefMutMulti<'a, K, V> {
+impl<'a, K, V> Deref for RefMutMulti<'a, K, V> {
     type Target = V;
 
     fn deref(&self) -> &V {
@@ -83,7 +82,7 @@ impl<'a, K: Eq + Hash, V> Deref for RefMutMulti<'a, K, V> {
     }
 }
 
-impl<'a, K: Eq + Hash, V> DerefMut for RefMutMulti<'a, K, V> {
+impl<'a, K, V> DerefMut for RefMutMulti<'a, K, V> {
     fn deref_mut(&mut self) -> &mut V {
         self.value_mut()
     }

--- a/src/mapref/one.rs
+++ b/src/mapref/one.rs
@@ -1,7 +1,6 @@
 use crate::lock::{RwLockReadGuardDetached, RwLockWriteGuardDetached};
-use core::hash::Hash;
+use core::fmt::{self, Debug, Display};
 use core::ops::{Deref, DerefMut};
-use std::fmt::{Debug, Formatter};
 
 pub struct Ref<'a, K, V> {
     _guard: RwLockReadGuardDetached<'a>,
@@ -9,7 +8,7 @@ pub struct Ref<'a, K, V> {
     v: &'a V,
 }
 
-impl<'a, K: Eq + Hash, V> Ref<'a, K, V> {
+impl<'a, K, V> Ref<'a, K, V> {
     pub(crate) fn new(guard: RwLockReadGuardDetached<'a>, k: &'a K, v: &'a V) -> Self {
         Self {
             _guard: guard,
@@ -57,8 +56,12 @@ impl<'a, K: Eq + Hash, V> Ref<'a, K, V> {
     }
 }
 
-impl<'a, K: Eq + Hash + Debug, V: Debug> Debug for Ref<'a, K, V> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl<'a, K, V> Debug for Ref<'a, K, V>
+where
+    K: Debug,
+    V: Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Ref")
             .field("k", &self.k)
             .field("v", &self.v)
@@ -66,7 +69,7 @@ impl<'a, K: Eq + Hash + Debug, V: Debug> Debug for Ref<'a, K, V> {
     }
 }
 
-impl<'a, K: Eq + Hash, V> Deref for Ref<'a, K, V> {
+impl<'a, K, V> Deref for Ref<'a, K, V> {
     type Target = V;
 
     fn deref(&self) -> &V {
@@ -80,7 +83,7 @@ pub struct RefMut<'a, K, V> {
     v: &'a mut V,
 }
 
-impl<'a, K: Eq + Hash, V> RefMut<'a, K, V> {
+impl<'a, K, V> RefMut<'a, K, V> {
     pub(crate) fn new(guard: RwLockWriteGuardDetached<'a>, k: &'a K, v: &'a mut V) -> Self {
         Self { guard, k, v }
     }
@@ -142,8 +145,12 @@ impl<'a, K: Eq + Hash, V> RefMut<'a, K, V> {
     }
 }
 
-impl<'a, K: Eq + Hash + Debug, V: Debug> Debug for RefMut<'a, K, V> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl<'a, K, V> Debug for RefMut<'a, K, V>
+where
+    K: Debug,
+    V: Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RefMut")
             .field("k", &self.k)
             .field("v", &self.v)
@@ -151,7 +158,7 @@ impl<'a, K: Eq + Hash + Debug, V: Debug> Debug for RefMut<'a, K, V> {
     }
 }
 
-impl<'a, K: Eq + Hash, V> Deref for RefMut<'a, K, V> {
+impl<'a, K, V> Deref for RefMut<'a, K, V> {
     type Target = V;
 
     fn deref(&self) -> &V {
@@ -159,7 +166,7 @@ impl<'a, K: Eq + Hash, V> Deref for RefMut<'a, K, V> {
     }
 }
 
-impl<'a, K: Eq + Hash, V> DerefMut for RefMut<'a, K, V> {
+impl<'a, K, V> DerefMut for RefMut<'a, K, V> {
     fn deref_mut(&mut self) -> &mut V {
         self.value_mut()
     }
@@ -171,7 +178,7 @@ pub struct MappedRef<'a, K, T: ?Sized> {
     v: &'a T,
 }
 
-impl<'a, K: Eq + Hash, T: ?Sized> MappedRef<'a, K, T> {
+impl<'a, K, T: ?Sized> MappedRef<'a, K, T> {
     pub fn key(&self) -> &K {
         self.pair().0
     }
@@ -212,8 +219,12 @@ impl<'a, K: Eq + Hash, T: ?Sized> MappedRef<'a, K, T> {
     }
 }
 
-impl<'a, K: Eq + Hash + Debug, T: Debug + ?Sized> Debug for MappedRef<'a, K, T> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl<'a, K, T: ?Sized> Debug for MappedRef<'a, K, T>
+where
+    K: Debug,
+    T: Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MappedRef")
             .field("k", &self.k)
             .field("v", &self.v)
@@ -221,7 +232,7 @@ impl<'a, K: Eq + Hash + Debug, T: Debug + ?Sized> Debug for MappedRef<'a, K, T> 
     }
 }
 
-impl<'a, K: Eq + Hash, T: ?Sized> Deref for MappedRef<'a, K, T> {
+impl<'a, K, T: ?Sized> Deref for MappedRef<'a, K, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -229,16 +240,20 @@ impl<'a, K: Eq + Hash, T: ?Sized> Deref for MappedRef<'a, K, T> {
     }
 }
 
-impl<'a, K: Eq + Hash, T: std::fmt::Display + ?Sized> std::fmt::Display for MappedRef<'a, K, T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(self.value(), f)
+impl<'a, K, T: ?Sized> Display for MappedRef<'a, K, T>
+where
+    T: Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(self.value(), f)
     }
 }
 
-impl<'a, K: Eq + Hash, T: ?Sized + AsRef<TDeref>, TDeref: ?Sized> AsRef<TDeref>
-    for MappedRef<'a, K, T>
+impl<'a, K, T: ?Sized, U: ?Sized> AsRef<U> for MappedRef<'a, K, T>
+where
+    T: AsRef<U>,
 {
-    fn as_ref(&self) -> &TDeref {
+    fn as_ref(&self) -> &U {
         self.value().as_ref()
     }
 }
@@ -249,7 +264,7 @@ pub struct MappedRefMut<'a, K, T: ?Sized> {
     v: &'a mut T,
 }
 
-impl<'a, K: Eq + Hash, T: ?Sized> MappedRefMut<'a, K, T> {
+impl<'a, K, T: ?Sized> MappedRefMut<'a, K, T> {
     pub fn key(&self) -> &K {
         self.pair().0
     }
@@ -270,9 +285,9 @@ impl<'a, K: Eq + Hash, T: ?Sized> MappedRefMut<'a, K, T> {
         (self.k, self.v)
     }
 
-    pub fn map<F, T2: ?Sized>(self, f: F) -> MappedRefMut<'a, K, T2>
+    pub fn map<F, U: ?Sized>(self, f: F) -> MappedRefMut<'a, K, U>
     where
-        F: FnOnce(&mut T) -> &mut T2,
+        F: FnOnce(&mut T) -> &mut U,
     {
         MappedRefMut {
             _guard: self._guard,
@@ -281,9 +296,9 @@ impl<'a, K: Eq + Hash, T: ?Sized> MappedRefMut<'a, K, T> {
         }
     }
 
-    pub fn try_map<F, T2: ?Sized>(self, f: F) -> Result<MappedRefMut<'a, K, T2>, Self>
+    pub fn try_map<F, U: ?Sized>(self, f: F) -> Result<MappedRefMut<'a, K, U>, Self>
     where
-        F: FnOnce(&mut T) -> Option<&mut T2>,
+        F: FnOnce(&mut T) -> Option<&mut U>,
     {
         let v = match f(unsafe { &mut *(self.v as *mut _) }) {
             Some(v) => v,
@@ -299,8 +314,12 @@ impl<'a, K: Eq + Hash, T: ?Sized> MappedRefMut<'a, K, T> {
     }
 }
 
-impl<'a, K: Eq + Hash + Debug, T: Debug + ?Sized> Debug for MappedRefMut<'a, K, T> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl<'a, K, T: ?Sized> Debug for MappedRefMut<'a, K, T>
+where
+    K: Debug,
+    T: Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MappedRefMut")
             .field("k", &self.k)
             .field("v", &self.v)
@@ -308,7 +327,7 @@ impl<'a, K: Eq + Hash + Debug, T: Debug + ?Sized> Debug for MappedRefMut<'a, K, 
     }
 }
 
-impl<'a, K: Eq + Hash, T: ?Sized> Deref for MappedRefMut<'a, K, T> {
+impl<'a, K, T: ?Sized> Deref for MappedRefMut<'a, K, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -316,7 +335,7 @@ impl<'a, K: Eq + Hash, T: ?Sized> Deref for MappedRefMut<'a, K, T> {
     }
 }
 
-impl<'a, K: Eq + Hash, T: ?Sized> DerefMut for MappedRefMut<'a, K, T> {
+impl<'a, K, T: ?Sized> DerefMut for MappedRefMut<'a, K, T> {
     fn deref_mut(&mut self) -> &mut T {
         self.value_mut()
     }

--- a/src/rayon/map.rs
+++ b/src/rayon/map.rs
@@ -11,7 +11,7 @@ impl<K, V, S> ParallelExtend<(K, V)> for DashMap<K, V, S>
 where
     K: Send + Sync + Eq + Hash,
     V: Send + Sync,
-    S: Send + Sync + Clone + BuildHasher,
+    S: Send + Sync + BuildHasher,
 {
     fn par_extend<I>(&mut self, par_iter: I)
     where
@@ -27,7 +27,7 @@ impl<K, V, S> ParallelExtend<(K, V)> for &'_ DashMap<K, V, S>
 where
     K: Send + Sync + Eq + Hash,
     V: Send + Sync,
-    S: Send + Sync + Clone + BuildHasher,
+    S: Send + Sync + BuildHasher,
 {
     fn par_extend<I>(&mut self, par_iter: I)
     where
@@ -44,7 +44,7 @@ impl<K, V, S> FromParallelIterator<(K, V)> for DashMap<K, V, S>
 where
     K: Send + Sync + Eq + Hash,
     V: Send + Sync,
-    S: Send + Sync + Clone + Default + BuildHasher,
+    S: Send + Sync + BuildHasher + Default,
 {
     fn from_par_iter<I>(par_iter: I) -> Self
     where
@@ -64,9 +64,9 @@ where
 
 impl<K, V, S> IntoParallelIterator for DashMap<K, V, S>
 where
-    K: Send + Eq + Hash,
+    K: Send,
     V: Send,
-    S: Send + Clone + BuildHasher,
+    S: Send,
 {
     type Iter = OwningIter<K, V>;
     type Item = (K, V);
@@ -84,7 +84,7 @@ pub struct OwningIter<K, V> {
 
 impl<K, V> ParallelIterator for OwningIter<K, V>
 where
-    K: Send + Eq + Hash,
+    K: Send,
     V: Send,
 {
     type Item = (K, V);
@@ -103,9 +103,9 @@ where
 // This impl also enables `IntoParallelRefIterator::par_iter`
 impl<'a, K, V, S> IntoParallelIterator for &'a DashMap<K, V, S>
 where
-    K: Send + Sync + Eq + Hash,
+    K: Send + Sync,
     V: Send + Sync,
-    S: Send + Sync + Clone + BuildHasher,
+    S: Send + Sync,
 {
     type Iter = Iter<'a, K, V>;
     type Item = RefMulti<'a, K, V>;
@@ -123,7 +123,7 @@ pub struct Iter<'a, K, V> {
 
 impl<'a, K, V> ParallelIterator for Iter<'a, K, V>
 where
-    K: Send + Sync + Eq + Hash,
+    K: Send + Sync,
     V: Send + Sync,
 {
     type Item = RefMulti<'a, K, V>;
@@ -152,7 +152,7 @@ where
 // This impl also enables `IntoParallelRefMutIterator::par_iter_mut`
 impl<'a, K, V> IntoParallelIterator for &'a mut DashMap<K, V>
 where
-    K: Send + Sync + Eq + Hash,
+    K: Send + Sync,
     V: Send + Sync,
 {
     type Iter = IterMut<'a, K, V>;
@@ -167,7 +167,7 @@ where
 
 impl<K, V, S> DashMap<K, V, S>
 where
-    K: Send + Sync + Eq + Hash,
+    K: Send + Sync,
     V: Send + Sync,
 {
     // Unlike `IntoParallelRefMutIterator::par_iter_mut`, we only _need_ `&self`.
@@ -184,7 +184,7 @@ pub struct IterMut<'a, K, V> {
 
 impl<'a, K, V> ParallelIterator for IterMut<'a, K, V>
 where
-    K: Send + Sync + Eq + Hash,
+    K: Send + Sync,
     V: Send + Sync,
 {
     type Item = RefMutMulti<'a, K, V>;

--- a/src/rayon/read_only.rs
+++ b/src/rayon/read_only.rs
@@ -1,14 +1,13 @@
 use crate::mapref::multiple::RefMulti;
 use crate::rayon::map::Iter;
 use crate::ReadOnlyView;
-use core::hash::{BuildHasher, Hash};
 use rayon::iter::IntoParallelIterator;
 
 impl<K, V, S> IntoParallelIterator for ReadOnlyView<K, V, S>
 where
-    K: Send + Eq + Hash,
+    K: Send,
     V: Send,
-    S: Send + Clone + BuildHasher,
+    S: Send,
 {
     type Iter = super::map::OwningIter<K, V>;
     type Item = (K, V);
@@ -23,9 +22,9 @@ where
 // This impl also enables `IntoParallelRefIterator::par_iter`
 impl<'a, K, V, S> IntoParallelIterator for &'a ReadOnlyView<K, V, S>
 where
-    K: Send + Sync + Eq + Hash,
+    K: Send + Sync,
     V: Send + Sync,
-    S: Send + Sync + Clone + BuildHasher,
+    S: Send + Sync,
 {
     type Iter = Iter<'a, K, V>;
     type Item = RefMulti<'a, K, V>;

--- a/src/rayon/set.rs
+++ b/src/rayon/set.rs
@@ -7,7 +7,7 @@ use rayon::iter::{FromParallelIterator, IntoParallelIterator, ParallelExtend, Pa
 impl<K, S> ParallelExtend<K> for DashSet<K, S>
 where
     K: Send + Sync + Eq + Hash,
-    S: Send + Sync + Clone + BuildHasher,
+    S: Send + Sync + BuildHasher,
 {
     fn par_extend<I>(&mut self, par_iter: I)
     where
@@ -22,7 +22,7 @@ where
 impl<K, S> ParallelExtend<K> for &'_ DashSet<K, S>
 where
     K: Send + Sync + Eq + Hash,
-    S: Send + Sync + Clone + BuildHasher,
+    S: Send + Sync + BuildHasher,
 {
     fn par_extend<I>(&mut self, par_iter: I)
     where
@@ -38,7 +38,7 @@ where
 impl<K, S> FromParallelIterator<K> for DashSet<K, S>
 where
     K: Send + Sync + Eq + Hash,
-    S: Send + Sync + Clone + Default + BuildHasher,
+    S: Send + Sync + BuildHasher + Default,
 {
     fn from_par_iter<I>(par_iter: I) -> Self
     where
@@ -52,8 +52,8 @@ where
 
 impl<K, S> IntoParallelIterator for DashSet<K, S>
 where
-    K: Send + Eq + Hash,
-    S: Send + Clone + BuildHasher,
+    K: Send,
+    S: Send,
 {
     type Iter = OwningIter<K>;
     type Item = K;
@@ -71,7 +71,7 @@ pub struct OwningIter<K> {
 
 impl<K> ParallelIterator for OwningIter<K>
 where
-    K: Send + Eq + Hash,
+    K: Send,
 {
     type Item = K;
 
@@ -86,8 +86,8 @@ where
 // This impl also enables `IntoParallelRefIterator::par_iter`
 impl<'a, K, S> IntoParallelIterator for &'a DashSet<K, S>
 where
-    K: Send + Sync + Eq + Hash,
-    S: Send + Sync + Clone + BuildHasher,
+    K: Send + Sync,
+    S: Send + Sync,
 {
     type Iter = Iter<'a, K>;
     type Item = RefMulti<'a, K>;
@@ -105,7 +105,7 @@ pub struct Iter<'a, K> {
 
 impl<'a, K> ParallelIterator for Iter<'a, K>
 where
-    K: Send + Sync + Eq + Hash,
+    K: Send + Sync,
 {
     type Item = RefMulti<'a, K>;
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -10,11 +10,7 @@ pub struct DashMapVisitor<K, V, S> {
     marker: PhantomData<fn() -> DashMap<K, V, S>>,
 }
 
-impl<K, V, S> DashMapVisitor<K, V, S>
-where
-    K: Eq + Hash,
-    S: BuildHasher + Clone,
-{
+impl<K, V, S> DashMapVisitor<K, V, S> {
     fn new() -> Self {
         DashMapVisitor {
             marker: PhantomData,
@@ -26,7 +22,7 @@ impl<'de, K, V, S> Visitor<'de> for DashMapVisitor<K, V, S>
 where
     K: Deserialize<'de> + Eq + Hash,
     V: Deserialize<'de>,
-    S: BuildHasher + Clone + Default,
+    S: BuildHasher + Default,
 {
     type Value = DashMap<K, V, S>;
 
@@ -53,21 +49,20 @@ impl<'de, K, V, S> Deserialize<'de> for DashMap<K, V, S>
 where
     K: Deserialize<'de> + Eq + Hash,
     V: Deserialize<'de>,
-    S: BuildHasher + Clone + Default,
+    S: BuildHasher + Default,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        deserializer.deserialize_map(DashMapVisitor::<K, V, S>::new())
+        deserializer.deserialize_map(DashMapVisitor::new())
     }
 }
 
 impl<K, V, H> Serialize for DashMap<K, V, H>
 where
-    K: Serialize + Eq + Hash,
+    K: Serialize,
     V: Serialize,
-    H: BuildHasher + Clone,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -87,11 +82,7 @@ pub struct DashSetVisitor<K, S> {
     marker: PhantomData<fn() -> DashSet<K, S>>,
 }
 
-impl<K, S> DashSetVisitor<K, S>
-where
-    K: Eq + Hash,
-    S: BuildHasher + Clone,
-{
+impl<K, S> DashSetVisitor<K, S> {
     fn new() -> Self {
         DashSetVisitor {
             marker: PhantomData,
@@ -102,7 +93,7 @@ where
 impl<'de, K, S> Visitor<'de> for DashSetVisitor<K, S>
 where
     K: Deserialize<'de> + Eq + Hash,
-    S: BuildHasher + Clone + Default,
+    S: BuildHasher + Default,
 {
     type Value = DashSet<K, S>;
 
@@ -128,20 +119,19 @@ where
 impl<'de, K, S> Deserialize<'de> for DashSet<K, S>
 where
     K: Deserialize<'de> + Eq + Hash,
-    S: BuildHasher + Clone + Default,
+    S: BuildHasher + Default,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        deserializer.deserialize_seq(DashSetVisitor::<K, S>::new())
+        deserializer.deserialize_seq(DashSetVisitor::new())
     }
 }
 
 impl<K, H> Serialize for DashSet<K, H>
 where
-    K: Serialize + Eq + Hash,
-    H: BuildHasher + Clone,
+    K: Serialize,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -169,35 +159,35 @@ macro_rules! serialize_impl {
 }
 
 // Map
-impl<'a, K: Eq + Hash, V: Serialize> Serialize for mapref::multiple::RefMulti<'a, K, V> {
+impl<'a, K, V: Serialize> Serialize for mapref::multiple::RefMulti<'a, K, V> {
     serialize_impl! {}
 }
 
-impl<'a, K: Eq + Hash, V: Serialize> Serialize for mapref::multiple::RefMutMulti<'a, K, V> {
+impl<'a, K, V: Serialize> Serialize for mapref::multiple::RefMutMulti<'a, K, V> {
     serialize_impl! {}
 }
 
-impl<'a, K: Eq + Hash, V: Serialize> Serialize for mapref::one::Ref<'a, K, V> {
+impl<'a, K, V: Serialize> Serialize for mapref::one::Ref<'a, K, V> {
     serialize_impl! {}
 }
 
-impl<'a, K: Eq + Hash, V: Serialize> Serialize for mapref::one::RefMut<'a, K, V> {
+impl<'a, K, V: Serialize> Serialize for mapref::one::RefMut<'a, K, V> {
     serialize_impl! {}
 }
 
-impl<'a, K: Eq + Hash, T: Serialize> Serialize for mapref::one::MappedRef<'a, K, T> {
+impl<'a, K, T: Serialize> Serialize for mapref::one::MappedRef<'a, K, T> {
     serialize_impl! {}
 }
 
-impl<'a, K: Eq + Hash, T: Serialize> Serialize for mapref::one::MappedRefMut<'a, K, T> {
+impl<'a, K, T: Serialize> Serialize for mapref::one::MappedRefMut<'a, K, T> {
     serialize_impl! {}
 }
 
 // Set
-impl<'a, V: Hash + Eq + Serialize> Serialize for setref::multiple::RefMulti<'a, V> {
+impl<'a, V: Serialize> Serialize for setref::multiple::RefMulti<'a, V> {
     serialize_impl! {}
 }
 
-impl<'a, V: Hash + Eq + Serialize> Serialize for setref::one::Ref<'a, V> {
+impl<'a, V: Serialize> Serialize for setref::one::Ref<'a, V> {
     serialize_impl! {}
 }

--- a/src/setref/multiple.rs
+++ b/src/setref/multiple.rs
@@ -1,12 +1,11 @@
 use crate::mapref;
-use core::hash::Hash;
 use core::ops::Deref;
 
 pub struct RefMulti<'a, K> {
     inner: mapref::multiple::RefMulti<'a, K, ()>,
 }
 
-impl<'a, K: Eq + Hash> RefMulti<'a, K> {
+impl<'a, K> RefMulti<'a, K> {
     pub(crate) fn new(inner: mapref::multiple::RefMulti<'a, K, ()>) -> Self {
         Self { inner }
     }
@@ -16,7 +15,7 @@ impl<'a, K: Eq + Hash> RefMulti<'a, K> {
     }
 }
 
-impl<'a, K: Eq + Hash> Deref for RefMulti<'a, K> {
+impl<'a, K> Deref for RefMulti<'a, K> {
     type Target = K;
 
     fn deref(&self) -> &K {

--- a/src/setref/one.rs
+++ b/src/setref/one.rs
@@ -1,12 +1,11 @@
 use crate::mapref;
-use core::hash::Hash;
 use core::ops::Deref;
 
 pub struct Ref<'a, K> {
     inner: mapref::one::Ref<'a, K, ()>,
 }
 
-impl<'a, K: Eq + Hash> Ref<'a, K> {
+impl<'a, K> Ref<'a, K> {
     pub(crate) fn new(inner: mapref::one::Ref<'a, K, ()>) -> Self {
         Self { inner }
     }
@@ -16,7 +15,7 @@ impl<'a, K: Eq + Hash> Ref<'a, K> {
     }
 }
 
-impl<'a, K: Eq + Hash> Deref for Ref<'a, K> {
+impl<'a, K> Deref for Ref<'a, K> {
     type Target = K;
 
     fn deref(&self) -> &K {


### PR DESCRIPTION
This greatly reduces the number of `K: Eq + Hash` bounds peppered throughout the library and removes the `Clone` requirement on the choice of hasher, bringing the API closer in line with that of [`std::collections::HashMap`](https://doc.rust-lang.org/stable/std/collections/struct.HashMap.html).