### PR TITLE
Bumped hashbrown to 0.16.1 (newest version))

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ dependencies = [
  "cfg-if",
  "crossbeam-utils",
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
  "lock_api",
  "parking_lot_core",
  "rayon",
@@ -84,6 +84,12 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "libc"
@@ -210,7 +216,7 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e29e4cac0f1acdbbe7b4deb46876a04246dc6abf60b6f2587bef8ae327cd134c"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.2",
  "typesize-derive",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ inline-more = ["hashbrown/inline-more"]
 lock_api = "0.4.12"
 parking_lot_core = "0.9.10"
 equivalent = "1.0.1"
-hashbrown = { version = "0.15.2", default-features = false }
+hashbrown = { version = "0.16.1", default-features = false }
 serde = { version = "1.0.217", optional = true, features = ["derive"] }
 cfg-if = "1.0.0"
 rayon = { version = "1.10.0", optional = true }


### PR DESCRIPTION
all tests pass.